### PR TITLE
Add info when user wants to close topic without choosing "best" answer

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -175,3 +175,27 @@ function qa_ajax_error()
 {
 	alert('Unexpected response from server - please try again or switch off Javascript.');
 }
+
+
+/*
+ *	Feature: inform user about marking best answer, when he wants to close a topic
+ */
+ ;(function(document)
+ {
+	 'use strict';
+	 
+	window.addEventListener('DOMContentLoaded', function()
+	{
+		var parent = document.querySelector('.qa-c-form .qa-form-tall-table tbody');
+		var last = document.querySelector('.qa-c-form .qa-form-tall-table tbody tr:last-child');
+		var informParent = document.createElement('tr');
+		var inform  = document.createElement('td'); 
+
+		inform.innerHTML = 'Jeśli otrzymałeś odpowiedź, która rozwiązała Twój problem - oznacz ją jako <span class="closing-topic-info-bold">"najlepsza"</span>. Pomoże to odwiedzającym ten temat znaleźć rozwiązanie opisanego problemu.';
+
+		inform.classList.add('closing-topic-info');
+		informParent.appendChild(inform);
+
+		parent.insertBefore(informParent, last);
+	});
+ }(document));

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4597,3 +4597,21 @@ a.sidebarnav:hover {
 .level-expert, .level-expert a {
 	color: #8a0fd1;
 }
+
+/*
+ *	Feature: inform user about marking best answer, when he wants to close a topic
+ */
+ .closing-topic-info 
+ {
+    border: 2px solid orange;
+    text-align: center;
+    padding: 5px 10px;
+    line-height: 18px;
+    color: orange;
+    font-weight: bold;
+}
+
+.closing-topic-info-bold 
+{
+    color: #2ecc71;
+}


### PR DESCRIPTION
There are cases, when user closes his topic (question) without marking answer, which helped him at most, as "the best". It causes people, who will be later visiting that topic not to quickly find most helpful answer for discussed issue.
Provided script shows information, that user should mark most helpful answer as "the best".