### PR TITLE
Remove unnecessary hash from tags when creating new question (post)

### DIFF
--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -300,13 +300,12 @@ function set_category_description(idprefix)
 /**
  * Feature - Remove unnecessary # from tags, when creating new post (question)
  */ 
-( function(document) {
+( function( document ) {
 	
 	'use strict';
 	 
 	 // wait for DOM to load
-	 window.addEventListener('DOMContentLoaded', function()
-	 {
+	 window.addEventListener('DOMContentLoaded', function() {
 		// get DOM elements: "tags" input and button "Zadaj pytanie"
 		var tags = document.getElementById( 'tags' );
 		var askQuestionBtn = document.querySelector( 'input[value="Zadaj pytanie"]' );

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -300,35 +300,36 @@ function set_category_description(idprefix)
 /**
  * Feature - Remove unnecessary # from tags, when creating new post (question)
  */ 
-{	 
+( function(document) {
 	
 	'use strict';
 	 
 	// wait for DOM to load
-	window.addEventListener( 'DOMContentLoaded', ( ) => {		
+	window.addEventListener( 'DOMContentLoaded', function() {
 	
 		// get DOM elements: "tags" input and button "Zadaj pytanie"
-		const tags = document.getElementById( 'tags' );
-		const askQuestionBtn = document.querySelector( 'input[value="Zadaj pytanie"]' );
+		var tags = document.getElementById( 'tags' );
+		var askQuestionBtn = document.querySelector( 'input[value="Zadaj pytanie"]' );
 		
 		// when user clicks "Zadaj pytanie"
-		askQuestionBtn.addEventListener( 'click', ( ) => {		
+		askQuestionBtn.addEventListener( 'click', function() {
 			
-			let allTags = tags.value.split( ' ' );
+			var allTags = tags.value.split( ' ' );
 			
 			/*
 			 * Filter tags: when a single tag has # character on 0 position, remove it
 			 * For example: "#problem" will be filtered to "problem"
 			 */
-			for ( let i = 0, len = allTags.length; i < len; i++ ) {
+			for ( var i = 0, len = allTags.length; i < len; i++ ) {
 				
-				if ( allTags[ i ].indexOf( '#' ) === 0 )
+				if ( allTags[ i ].indexOf( '#' ) === 0 ) {
 					allTags[ i ] = allTags[ i ].slice( 1 );
-				
+				}
+
 			}
 			
 		} );		
 		
 	 } );	 
 	 
- };
+ } ( document ) );

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -304,9 +304,9 @@ function set_category_description(idprefix)
 	
 	'use strict';
 	 
-	// wait for DOM to load
-	window.addEventListener( 'DOMContentLoaded', function() {
-	
+	 // wait for DOM to load
+	 window.addEventListener('DOMContentLoaded', function()
+	 {
 		// get DOM elements: "tags" input and button "Zadaj pytanie"
 		var tags = document.getElementById( 'tags' );
 		var askQuestionBtn = document.querySelector( 'input[value="Zadaj pytanie"]' );

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -304,41 +304,28 @@ function set_category_description(idprefix)
  {
 	 'use strict';
 	 
+	 // wait for DOM to load
 	 window.addEventListener('DOMContentLoaded', function()
 	 {
+		// get DOM elements: "tags" input and button "Zadaj pytanie"
 		var tags = document.getElementById('tags');
 		var askQuestionBtn = document.querySelector('input[value="Zadaj pytanie"]');
 		
-		/*tags.addEventListener('blur', function()
-		{
-			
-		});*/
-		
+		// when user clicks "Zadaj pytanie"
 		askQuestionBtn.addEventListener('click', function(ev)
-		{
-			////
-			ev.preventDefault();
-			////
+		{					
+			// get written tags and split them
+			var allTags =  tags.value.split(' ');
 			
-			var hashTags =  tags.value.split(' ');
-			
-			var filteredTags = hashTags.filter(function(hash)
+			// filter tags, accept only those without # and those like "C#"
+			var filteredTags = allTags.filter(function(hash)
 			{
 				if (hash.indexOf('#') < 0 || hash.toLowerCase().indexOf('c#') > -1)
-				{
-					console.log('OK: ', hash);
-					
 					return hash;					
-				} else console.log('REMOVED: ', hash);
-					
 			});
 			
-			console.log('splitted: ', hashTags, ' >> ', filteredTags);
-			
+			// put filtered tags into "tags" input - separated by blank space (' ')
 			tags.value = filteredTags.join(' ');
 		});
-	 });
-	 
-	 
-	 
+	 });	 
  }(document));

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -297,32 +297,38 @@ function set_category_description(idprefix)
 	}
 }
 
-/*
+/**
  * Feature - Remove unnecessary # from tags, when creating new post (question)
  */ 
- ;( ( document ) => {	 
+{	 
+	
 	'use strict';
 	 
 	// wait for DOM to load
 	window.addEventListener( 'DOMContentLoaded', ( ) => {		
+	
 		// get DOM elements: "tags" input and button "Zadaj pytanie"
 		const tags = document.getElementById( 'tags' );
 		const askQuestionBtn = document.querySelector( 'input[value="Zadaj pytanie"]' );
 		
 		// when user clicks "Zadaj pytanie"
-		askQuestionBtn.addEventListener( 'click', ( ev ) => {		
-			// get written tags and split them
-			const allTags = tags.value.split( ' ' );
+		askQuestionBtn.addEventListener( 'click', ( ) => {		
 			
-			// filter tags, accept only those without # and those like "C#"
-			let filteredTags = [];
+			let allTags = tags.value.split( ' ' );
 			
-			allTags.forEach( ( hash ) => { 
-				hash.indexOf( '#' ) === 0 ? filteredTags.push( hash.slice( 1 ) ) : filteredTags.push( hash );
-			} );
+			/*
+			 * Filter tags: when a single tag has # character on 0 position, remove it
+			 * For example: "#problem" will be filtered to "problem"
+			 */
+			for ( let i = 0, len = allTags.length; i < len; i++ ) {
+				
+				if ( allTags[ i ].indexOf( '#' ) === 0 )
+					allTags[ i ] = allTags[ i ].slice( 1 );
+				
+			}
 			
-			// put filtered tags into "tags" input - separated by blank space (' ')
-			tags.value = filteredTags.join( ' ' );
 		} );		
+		
 	 } );	 
- } ) ( document );
+	 
+ };

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -300,31 +300,30 @@ function set_category_description(idprefix)
 /*
  * Feature - Remove unnecessary # from tags, when creating new post (question)
  */ 
- ;(function (document)
- {	 
+ ;( function ( document )
+ {	 	 
 	 'use strict';
 	 
 	 // wait for DOM to load
-	 window.addEventListener('DOMContentLoaded', function()
-	 {
+	 window.addEventListener( 'DOMContentLoaded', ( ) => {
 		// get DOM elements: "tags" input and button "Zadaj pytanie"
-		var tags = document.getElementById('tags');
-		var askQuestionBtn = document.querySelector('input[value="Zadaj pytanie"]');
+		const tags = document.getElementById( 'tags' );
+		const askQuestionBtn = document.querySelector( 'input[value="Zadaj pytanie"]' );
 		
 		// when user clicks "Zadaj pytanie"
-		askQuestionBtn.addEventListener('click', function(ev)
-		{					
+		askQuestionBtn.addEventListener( 'click', ( ev ) => {
 			// get written tags and split them
-			var allTags =  tags.value.split(' ');
+			const allTags = tags.value.split( ' ' );
 			
 			// filter tags, accept only those without # and those like "C#"
-			var filteredTags = allTags.filter(function(hash)
-			{				
-				return hash.indexOf('#') < 0 || hash.indexOf('#') === 1;
-			});
+			let filteredTags = [];
+			
+			allTags.forEach( ( hash ) => { 
+				hash.indexOf( '#' ) === 0 ? filteredTags.push( hash.slice( 1 ) ) : filteredTags.push( hash );
+			} );
 			
 			// put filtered tags into "tags" input - separated by blank space (' ')
-			tags.value = filteredTags.join(' ');
-		});
-	 });	 
- }(document));
+			tags.value = filteredTags.join( ' ' );
+		} );
+	 } );	 
+ } ( document ) );

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -296,3 +296,49 @@ function set_category_description(idprefix)
 		n.innerHTML=desc;
 	}
 }
+
+/*
+ * Feature - Remove unnecessary # from tags, when creating new post (question)
+ */ 
+ ;(function (document)
+ {
+	 'use strict';
+	 
+	 window.addEventListener('DOMContentLoaded', function()
+	 {
+		var tags = document.getElementById('tags');
+		var askQuestionBtn = document.querySelector('input[value="Zadaj pytanie"]');
+		
+		/*tags.addEventListener('blur', function()
+		{
+			
+		});*/
+		
+		askQuestionBtn.addEventListener('click', function(ev)
+		{
+			////
+			ev.preventDefault();
+			////
+			
+			var hashTags =  tags.value.split(' ');
+			
+			var filteredTags = hashTags.filter(function(hash)
+			{
+				if (hash.indexOf('#') < 0 || hash.toLowerCase().indexOf('c#') > -1)
+				{
+					console.log('OK: ', hash);
+					
+					return hash;					
+				} else console.log('REMOVED: ', hash);
+					
+			});
+			
+			console.log('splitted: ', hashTags, ' >> ', filteredTags);
+			
+			tags.value = filteredTags.join(' ');
+		});
+	 });
+	 
+	 
+	 
+ }(document));

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -300,18 +300,17 @@ function set_category_description(idprefix)
 /*
  * Feature - Remove unnecessary # from tags, when creating new post (question)
  */ 
- ;( function ( document )
- {	 	 
-	 'use strict';
+ ;( ( document ) => {	 
+	'use strict';
 	 
-	 // wait for DOM to load
-	 window.addEventListener( 'DOMContentLoaded', ( ) => {
+	// wait for DOM to load
+	window.addEventListener( 'DOMContentLoaded', ( ) => {		
 		// get DOM elements: "tags" input and button "Zadaj pytanie"
 		const tags = document.getElementById( 'tags' );
 		const askQuestionBtn = document.querySelector( 'input[value="Zadaj pytanie"]' );
 		
 		// when user clicks "Zadaj pytanie"
-		askQuestionBtn.addEventListener( 'click', ( ev ) => {
+		askQuestionBtn.addEventListener( 'click', ( ev ) => {		
 			// get written tags and split them
 			const allTags = tags.value.split( ' ' );
 			
@@ -324,6 +323,6 @@ function set_category_description(idprefix)
 			
 			// put filtered tags into "tags" input - separated by blank space (' ')
 			tags.value = filteredTags.join( ' ' );
-		} );
+		} );		
 	 } );	 
- } ( document ) );
+ } ) ( document );

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -301,7 +301,7 @@ function set_category_description(idprefix)
  * Feature - Remove unnecessary # from tags, when creating new post (question)
  */ 
  ;(function (document)
- {
+ {	 
 	 'use strict';
 	 
 	 // wait for DOM to load
@@ -319,9 +319,8 @@ function set_category_description(idprefix)
 			
 			// filter tags, accept only those without # and those like "C#"
 			var filteredTags = allTags.filter(function(hash)
-			{
-				if (hash.indexOf('#') < 0 || hash.toLowerCase().indexOf('c#') > -1)
-					return hash;					
+			{				
+				return hash.indexOf('#') < 0 || hash.indexOf('#') === 1;
 			});
 			
 			// put filtered tags into "tags" input - separated by blank space (' ')

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -300,12 +300,13 @@ function set_category_description(idprefix)
 /**
  * Feature - Remove unnecessary # from tags, when creating new post (question)
  */ 
-( function( document ) {
+;( function( document ) {
 	
 	'use strict';
 	 
 	 // wait for DOM to load
 	 window.addEventListener('DOMContentLoaded', function() {
+	
 		// get DOM elements: "tags" input and button "Zadaj pytanie"
 		var tags = document.getElementById( 'tags' );
 		var askQuestionBtn = document.querySelector( 'input[value="Zadaj pytanie"]' );


### PR DESCRIPTION
According to: https://trello.com/c/qJ8rbIeo/33-usuwanie-znaku-z-tagow

Here is a script that removes unnecessary hash symbols "#" (ommiting values like "C#") from tags written inside `<input id="tags">` when user is creating a new post (asking a question).
