### PR TITLE
Recognize when user writes code without placing it into code-block inside editor

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -453,3 +453,66 @@ function qa_ajax_error()
 
 	});
 }(document));
+
+/*
+ * Feature: recognize if user wrote some code, but haven't placed it into block code
+ */
+ ;(function (document)
+ {
+	 ////////
+	 console.clear();
+	 ////////
+	 
+	 'use strict';
+	 
+	 // taken from shBrushJScript.js
+	 var jsKeywords =	[
+		'break', 'case', 'catch', 'continue', 'default', 'delete',
+		'do', 'else', 'false', 'for', 'function', 'if', 'in', 'instanceof',
+		'new', 'null', 'return', 'super', 'switch', 'this', 'throw', 'true',
+		'try', 'typeof', 'var', 'while', 'with', '=', '==', '===', '{', '}'
+	];
+	 	 
+	 // when Forum (sub)page DOM is ready
+	window.addEventListener('DOMContentLoaded', function()
+	{
+		// find number in URL - so it's sure that topic is being viewed/opened
+		var url = location.pathname.split('/').findIndex(function(elem)
+		{
+			return Number(elem);
+		});
+		
+				
+		CKEDITOR.on('instanceReady', function(ev)
+		{
+			console.log('cke is ready...');
+			
+			document.querySelector('iframe.cke_wysiwyg_frame').contentDocument.body.addEventListener('blur', function(ev)
+			{
+				var editorData = CKEDITOR.instances[Object.keys(CKEDITOR.instances)].getData();
+				
+				console.log('[cke] OFF: ', editorData);
+				
+				var splittedData = editorData.split('\n\n');
+				var cleanedSplittedData = splittedData.map(function(textRow)
+				{
+					return textRow.slice(textRow.indexOf('>') + 1, textRow.lastIndexOf('<'));
+				});
+				
+				var recognizedCode = cleanedSplittedData.filter(function(dataRow)
+				{
+					var code = jsKeywords.filter(function(keyword)
+					{
+						return dataRow.indexOf(keyword) > -1;
+					});
+					
+					return code.length;
+					////console.log('founded code: ', foundedCode);
+				});
+				
+				console.log('recognized: ', recognizedCode);
+			});
+		});
+		
+	});	 
+ }(document));

--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -487,8 +487,10 @@ function qa_ajax_error()
 		{
 			console.log('cke is ready...');
 			
+			// watch when user will click beyond CKEDITOR - it'll loose focus
 			document.querySelector('iframe.cke_wysiwyg_frame').contentDocument.body.addEventListener('blur', function(ev)
 			{
+				// get data from current CKEDITOR instance
 				var editorData = CKEDITOR.instances[Object.keys(CKEDITOR.instances)].getData();
 				
 				console.log('[cke] OFF: ', editorData);


### PR DESCRIPTION
It's common situation that users place code just like usual text, instead of using appropriate block of code (it's not that bad if any block is used, even without correct language chosen).

I created alfa version of code recognition, which functioning principle isn't that hard - and I am not sure if this will work on "daily user" conditions (weird methods of typing code inside editor, like non standard amount of spaces and/or new lines etc.).

**Ideas of how could that work:**

**1.** script will check editor content according to category of question. So if "HTML i CSS" category will be chosen, script check if user wrote HTML/CSS code among plain text. 
**Pros:** quick searching (only languages that are withing chosen category). 
**Cons:** when user will choose inappropriate category, written code may not be recognized either partialy or entirely; on categories like mentioned "HTML i CSS" or "JavaScript, jQuery, AJAX" - there may be also `HTML` and/or `CSS` code;  if user use some library/framework, code may not be recognized at least partially as long as it has little common tags/expressions

**2.** script will check for all provided languages tags/expressions inside editor:
**Pros:** more probability of recognizing any code
**Cons:** less efficient; if - in the future - would be applied script that automatically match block-of-code language name to inserted code, a discussed at the moment script may cause wrong code interpretation - many languages have common expressions and depending on script overall recognition method, it may mess up recognition process.