### PR TITLE
Fixed script - run only when closing topic + added ES6 syntax

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -179,8 +179,8 @@ function qa_ajax_error()
 
 /*
  *	Feature: inform user about marking best answer, when he wants to close a topic
- */
- ;( ( document ) => {
+ */ 
+{
 	 
 	'use strict';
 	 
@@ -207,4 +207,4 @@ function qa_ajax_error()
 		
 	}
 	
- } ) ( document );
+ };

--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -180,8 +180,7 @@ function qa_ajax_error()
 /*
  *	Feature: inform user about marking best answer, when he wants to close a topic
  */
- ;( function( document )
- {
+ ;( ( document ) => {
 	 
 	'use strict';
 	 
@@ -208,4 +207,4 @@ function qa_ajax_error()
 		
 	}
 	
- } ( document) );
+ } ) ( document );

--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -180,22 +180,32 @@ function qa_ajax_error()
 /*
  *	Feature: inform user about marking best answer, when he wants to close a topic
  */
- ;(function(document)
+ ;( function( document )
  {
-	 'use strict';
 	 
-	window.addEventListener('DOMContentLoaded', function()
-	{
-		var parent = document.querySelector('.qa-c-form .qa-form-tall-table tbody');
-		var last = document.querySelector('.qa-c-form .qa-form-tall-table tbody tr:last-child');
-		var informParent = document.createElement('tr');
-		var inform  = document.createElement('td'); 
+	'use strict';
+	 
+	const closingTopicState = location.href.indexOf( 'state=close' );
+	
+	if ( closingTopicState > 0 ) {
+		
+		window.addEventListener('DOMContentLoaded', ( ) => {
+			
+			const last = document.querySelector( '.qa-c-form .qa-form-tall-table tbody tr:last-child' );
+			
+			let informParent = document.createElement( 'tr' );			
+			let parent = document.querySelector( '.qa-c-form .qa-form-tall-table tbody' );
+			let inform  = document.createElement( 'td' );
 
-		inform.innerHTML = 'Jeśli otrzymałeś odpowiedź, która rozwiązała Twój problem - oznacz ją jako <span class="closing-topic-info-bold">"najlepsza"</span>. Pomoże to odwiedzającym ten temat znaleźć rozwiązanie opisanego problemu.';
+			inform.innerHTML = 'Jeśli otrzymałeś odpowiedź, która rozwiązała Twój problem - oznacz ją jako <span class="closing-topic-info-bold">"najlepsza"</span>. Pomoże to odwiedzającym ten temat znaleźć rozwiązanie opisanego problemu.';
 
-		inform.classList.add('closing-topic-info');
-		informParent.appendChild(inform);
+			inform.classList.add( 'closing-topic-info' );
+			informParent.appendChild( inform );
 
-		parent.insertBefore(informParent, last);
-	});
- }(document));
+			parent.insertBefore( informParent, last );
+			
+		});
+		
+	}
+	
+ } ( document) );


### PR DESCRIPTION
Script was running unnecessary when any user has been adding comment to question. It was weird to see information about giving best answer, before closing topic, when neither Author was a visitor nor subpage was at closing topic state.

Also updated syntax to ES6.