### PR TITLE
Możliwość domyślnego ustawienia wysyłania e-mailowych powiadomień o aktywności w postach użytkownika

### DIFF
--- a/forum/qa-include/app/format.php
+++ b/forum/qa-include/app/format.php
@@ -1720,8 +1720,9 @@
 	Pass $fieldprefix to add a prefix to the form field names and IDs used.
 */
 	{
+		$send = qa_get_logged_in_user_field('activityemail');
 		$fields['notify']=array(
-			'tags' => 'name="'.$fieldprefix.'notify"',
+			'tags' => 'name="'.$fieldprefix.'notify"'.($send ? ' checked="checked"' : ''),
 			'type' => 'checkbox',
 			'value' => qa_html($innotify),
 		);

--- a/forum/qa-include/db/install.php
+++ b/forum/qa-include/db/install.php
@@ -117,7 +117,8 @@
 				'sessioncode' => 'CHAR(8) CHARACTER SET ascii NOT NULL DEFAULT \'\'', // for comparing against session cookie in browser
 				'sessionsource' => 'VARCHAR (16) CHARACTER SET ascii DEFAULT \'\'', // e.g. facebook, openid, etc...
 				'flags' => 'SMALLINT UNSIGNED NOT NULL DEFAULT 0', // see constants at top of qa-app-users.php
-				'pwemail' => 'SMALLINT UNSIGNED NOT NULL DEFAULT 1',
+				'pwemail' => 'TINYINT UNSIGNED NOT NULL DEFAULT 1',
+				'activityemail' => 'TINYINT UNSIGNED NOT NULL DEFAULT 0',
 				'wallposts' => 'MEDIUMINT NOT NULL DEFAULT 0', // cached count of wall posts
 				'PRIMARY KEY (userid)',
 				'KEY email (email)',

--- a/forum/qa-include/db/selects.php
+++ b/forum/qa-include/db/selects.php
@@ -1182,7 +1182,7 @@
 		return array(
 			'columns' => array(
 				'^users.userid', 'passsalt', 'passcheck' => 'HEX(passcheck)', 'email', 'level', 'emailcode', 'handle',
-				'created' => 'UNIX_TIMESTAMP(created)', 'sessioncode', 'sessionsource', 'flags', 'pwemail', 'loggedin' => 'UNIX_TIMESTAMP(loggedin)',
+				'created' => 'UNIX_TIMESTAMP(created)', 'sessioncode', 'sessionsource', 'flags', 'pwemail', 'activityemail', 'loggedin' => 'UNIX_TIMESTAMP(loggedin)',
 				'loginip' => 'INET_NTOA(loginip)', 'written' => 'UNIX_TIMESTAMP(written)', 'writeip' => 'INET_NTOA(writeip)',
 				'avatarblobid' => 'BINARY avatarblobid', // cast to BINARY due to MySQL bug which renders it signed in a union
 				'avatarwidth', 'avatarheight', 'points', 'wallposts',

--- a/forum/qa-include/lang/qa-lang-users.php
+++ b/forum/qa-include/lang/qa-lang-users.php
@@ -102,6 +102,8 @@
 		'private_messages_email' => 'Private message notifications:',
 		'private_messages_explanation' => 'Allow users to email you (without seeing your address)',
 		'private_messages_email_explanation' => 'Notify me by e-mail when we receive a private message',
+		'activity_email_notifications' => 'E-mail notifications about activity:',
+		'activity_email_notifications_explanation' => 'Default select the option to send notifications by e-mail (available while writing post) about new activity to your posts',
 		'profile_saved' => 'Profile saved',
 		'register_button' => 'Register',
 		'register_limit' => 'Too many registrations - please try again in an hour',

--- a/forum/qa-include/pages/account.php
+++ b/forum/qa-include/pages/account.php
@@ -72,6 +72,7 @@
 			$inemail = qa_post_text('email');
 			$inmessages = qa_post_text('messages');
 			$inmessagesemail = (int)qa_post_text('messages_email');
+			$inactivityemail = (int)qa_post_text('activity_email');
 			$inwallposts = qa_post_text('wall');
 			$inmailings = qa_post_text('mailings');
 			$inavatar = qa_post_text('avatar');
@@ -100,6 +101,10 @@
 
 				if ($inmessagesemail !== $useraccount['pwemail'] && ($inmessagesemail === 0 || $inmessagesemail === 1)) {
 					qa_db_query_sub('UPDATE ^users SET pwemail=# WHERE userid=#', $inmessagesemail, $userid);
+				}
+
+				if ($inactivityemail !== $useraccount['activityemail'] && ($inactivityemail === 0 || $inactivityemail === 1)) {
+					qa_db_query_sub('UPDATE ^users SET activityemail=# WHERE userid=#', $inactivityemail, $userid);
 				}
 
 				if (qa_opt('allow_private_messages'))
@@ -264,6 +269,14 @@
 				'type' => 'checkbox',
 				'value' => $useraccount['pwemail'],
 				'note' => qa_lang_html('users/private_messages_email_explanation'),
+			),
+
+			'activity_email' => array(
+				'label' => qa_lang_html('users/activity_email_notifications'),
+				'tags' => 'name="activity_email"',
+				'type' => 'checkbox',
+				'value' => $useraccount['activityemail'],
+				'note' => qa_lang_html('users/activity_email_notifications_explanation'),
 			),
 
 			'wall' => array(

--- a/forum/qa-lang/pl/qa-lang-users.php
+++ b/forum/qa-lang/pl/qa-lang-users.php
@@ -102,6 +102,8 @@
 		'private_messages_email_explanation' => 'Powiadamiaj mnie e-mailowo, gdy otrzymam wiadomość prywatną',
 		'private_messages' => 'Wiadomości prywatne:',
 		'private_messages_email' => 'Powiadomienia o wiadomościach prywatnych:',
+		'activity_email_notifications' => 'Powiadomienia e-mail o aktywnościach:',
+		'activity_email_notifications_explanation' => 'Domyślnie zaznaczaj opcję wysyłania powiadomień na e-mail (dostępna w momencie pisania posta) o nowej aktywności do Twoich postów',
 		'profile_saved' => 'Profil zapisany',
 		'wall_posts' => "Ściana Wpisów:",
 		'wall_posts_explanation' => "Zezwalaj użytkownikom na zamieszczanie wiadomości na ścianie (będziesz informowany o wpisie pocztą email)",


### PR DESCRIPTION
Dodałem opcję
> Domyślnie zaznaczaj opcję wysyłania powiadomień na e-mail (dostępna w momencie pisania posta) o nowej aktywności do Twoich postów

(w danych konta użytkownika) dzięki której można ustawić, aby opcja
> Powiadom mnie (_adres e-mail_), jeśli ktoś odpowie lub skomentuje moje pytanie

(widoczna podczas zadawania pytania, pisania odpowiedzi lub komentarza; odpowiednio przy odpowiedzi/komentarzu końcówka brzmi inaczej) była zawsze zaznaczona.

W chwili obecnej opcja ta zawsze jest odznaczona i dla osoby, która chciałaby zawsze dodawać powiadomienia na e-mail klikanie za każdym razem jest uciążliwe, a globalnie również nie chciałem tego włączać ponieważ część osób nie ma ochoty dostawać wszystkiego na email i tutaj odznaczanie za każdym razem byłoby uciążliwe. Stąd decyzja o wprowadzeniu indywidualnego ustawienia dla konta.

https://trello.com/c/UhGEU9tS/40-opcja-dla-u-ytkownika-aby-mia-domyslnie-zaznaczona-opcje-o-powiadomieniach-do-postow-na-email