### PR TITLE
Naprawa komentarzy w trybie edycji pytania

### DIFF
--- a/forum/qa-theme/SnowFlat/qa-styles-rtl.css
+++ b/forum/qa-theme/SnowFlat/qa-styles-rtl.css
@@ -354,6 +354,12 @@ h1 {
 		float: right;
 		margin: 0 20px 0 0;
 	}
+
+	.qa-q-view:after {
+		content: "";
+		clear: both;
+		display: block;
+	}
 }
 
 .qa-q-view-closed {

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -2445,6 +2445,12 @@ input[type="submit"], button {
 	border-bottom: 1px solid #bdc3c7;
 	display: block;
 }
+
+.qa-q-view {
+	background-color: white;
+	margin-bottom: 5px;
+}
+
 @media (max-width: 1179px) {
 	.qa-q-view-meta {
 		clear: left;
@@ -2455,14 +2461,30 @@ input[type="submit"], button {
 
 @media (max-width: 1179px) {
 	.qa-q-view-main {
+		padding: 20px;
+		background-color: white;
 		width: 100%;
+	}
+
+	.qa-q-view:after {
+		content: "";
+		clear: both;
+		display: block;
 	}
 }
 @media (min-width: 1180px) {
 	.qa-q-view-main {
 		float: left;
+		background-color: white;
+		padding: 20px;
 		margin: 0 0 0 20px;
 		width: 81%;
+	}
+
+	.qa-q-view:after {
+		content: "";
+		clear: both;
+		display: block;
 	}
 }
 


### PR DESCRIPTION
Naprawiłem komentarze, które nachodziły na tytuł bloku odpowiedzi w trybie edycji. Problem leżał głównie w niwelowaniu rozmiaru kontenera przez opływanie (czyli float).