### PR TITLE
Fix ansible for new VirtualBox and Vagrant

### DIFF
--- a/ansible/roles/php/handlers/main.yml
+++ b/ansible/roles/php/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: restart php5-fpm
-  service: name=php5-fpm enabled=yes state=restarted
+- name: restart php-fpm5.6
+  service: name=php5.6-fpm enabled=yes state=restarted

--- a/ansible/roles/php/tasks/configure.yml
+++ b/ansible/roles/php/tasks/configure.yml
@@ -1,11 +1,11 @@
 ---
-- stat: path=/etc/php5/apache2/php.ini
+- stat: path=/etc/php/5.6/apache2/php.ini
   register: modphp
 
-- stat: path=/etc/php5/fpm/php.ini
+- stat: path=/etc/php/5.6/fpm/php.ini
   register: phpfpm
 
-- stat: path=/etc/php5/cli/php.ini
+- stat: path=/etc/php/5.6/cli/php.ini
   register: phpcli
 
 - include: php-fpm.yml

--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -9,29 +9,27 @@
 
 - name: Install php5
   sudo: yes
-  apt: pkg=php5 state=latest
+  apt: pkg=php5.6 state=latest
 
 - name: Install php5-fpm
   sudo: yes
-  apt: pkg=php5-fpm state=latest
+  apt: pkg=php5.6-fpm state=latest
 
 - name: Install PHP Packages
   sudo: yes
   apt: pkg={{ item }} state=latest
-  with_items:
-    - php5-cli
-    - php5-intl
-    - php5-mcrypt
-    - php5-curl
-    - php5-imagick
-    - php5-common
-    - php5-memcache
-    - php5-mysql
-    - php5-readline
-    - php5-sqlite
-    - php5-gd
-  when: php.packages is defined
-
+  with_items: 
+   - php5.6-cli
+   - php5.6-intl
+   - php5.6-mcrypt
+   - php5.6-curl
+   - php5.6-imagick
+   - php5.6-common 
+   - php5.6-memcache
+   - php5.6-mysql 
+   - php5.6-readline
+   - php5.6-sqlite3
+   - php5.6-gd
 - include: configure.yml
 - include: pecl.yml
 - include:  php_ini_configure.yml

--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -18,7 +18,18 @@
 - name: Install PHP Packages
   sudo: yes
   apt: pkg={{ item }} state=latest
-  with_items: php.packages
+  with_items:
+    - php5-cli
+    - php5-intl
+    - php5-mcrypt
+    - php5-curl
+    - php5-imagick
+    - php5-common
+    - php5-memcache
+    - php5-mysql
+    - php5-readline
+    - php5-sqlite
+    - php5-gd
   when: php.packages is defined
 
 - include: configure.yml

--- a/ansible/roles/php/tasks/mod-php.yml
+++ b/ansible/roles/php/tasks/mod-php.yml
@@ -1,10 +1,10 @@
 ---
 - name: ensure timezone is set in apache2 php.ini
-  lineinfile: dest=/etc/php5/apache2/php.ini
+  lineinfile: dest=/etc/php/5.6/apache2/php.ini
               regexp='date.timezone ='
               line='date.timezone = {{ server.timezone }}'
 
 - name: enabling opcache
-  lineinfile: dest=/etc/php5/apache2/php.ini
+  lineinfile: dest=/etc/php/5.6/apache2/php.ini
               regexp=';?opcache.enable=\d'
               line='opcache.enable=1'

--- a/ansible/roles/php/tasks/php-cli.yml
+++ b/ansible/roles/php/tasks/php-cli.yml
@@ -1,10 +1,10 @@
 ---
 - name: ensure timezone is set in cli php.ini
-  lineinfile: dest=/etc/php5/cli/php.ini
+  lineinfile: dest=/etc/php/5.6/cli/php.ini
               regexp='date.timezone ='
               line='date.timezone = {{ server.timezone }}'
 
 - name: enabling opcache cli
-  lineinfile: dest=/etc/php5/cli/php.ini
+  lineinfile: dest=/etc/php/5.6/cli/php.ini
               regexp=';?opcache.enable_cli=\d'
               line='opcache.enable_cli=1'

--- a/ansible/roles/php/tasks/php-fpm.yml
+++ b/ansible/roles/php/tasks/php-fpm.yml
@@ -1,19 +1,19 @@
 ---
 - name: Set permissions on socket - owner
-  lineinfile: "dest=/etc/php5/fpm/pool.d/www.conf state=present regexp='^;?listen.owner' line='listen.owner = www-data'"
+  lineinfile: "dest=/etc/php/5.6/fpm/pool.d/www.conf state=present regexp='^;?listen.owner' line='listen.owner = www-data'"
 
 - name: Set permissions on socket - group
-  lineinfile: "dest=/etc/php5/fpm/pool.d/www.conf state=present regexp='^;?listen.group' line='listen.group = www-data'"
+  lineinfile: "dest=/etc/php/5.6/fpm/pool.d/www.conf state=present regexp='^;?listen.group' line='listen.group = www-data'"
 
 - name: Set permissions on socket - mode
-  lineinfile: "dest=/etc/php5/fpm/pool.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
-  notify: restart php5-fpm
+  lineinfile: "dest=/etc/php/5.6/fpm/pool.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
+  notify: restart php-fpm5.6
 
 - name: ensure timezone is set in fpm php.ini
-  lineinfile: dest=/etc/php5/fpm/php.ini
+  lineinfile: dest=/etc/php/5.6/fpm/php.ini
               regexp='date.timezone ='
               line='date.timezone = {{ server.timezone }}'
 - name: enabling opcache
-  lineinfile: dest=/etc/php5/fpm/php.ini
+  lineinfile: dest=/etc/php/5.6/fpm/php.ini
               regexp=';?opcache.enable=\d'
               line='opcache.enable=1'

--- a/ansible/roles/php/tasks/php_ini_configure.yml
+++ b/ansible/roles/php/tasks/php_ini_configure.yml
@@ -1,31 +1,31 @@
 ---
 # application tasks to be customized and to run after the main provision
 
-- name: Display Errors in /etc/php5/apache2/php.ini
-  shell: sed -i -e 's/^display_errors =.*/display_errors = On/g' /etc/php5/apache2/php.ini
+- name: Display Errors in /etc/php/5.6/apache2/php.ini
+  shell: sed -i -e 's/^display_errors =.*/display_errors = On/g' /etc/php/5.6/apache2/php.ini
   sudo: yes
 
-- name: Display Errors in /etc/php5/cli/php.ini
-  shell: sed -i -e 's/^display_errors =.*/display_errors = On/g' /etc/php5/cli/php.ini
+- name: Display Errors in /etc/php/5.6/cli/php.ini
+  shell: sed -i -e 's/^display_errors =.*/display_errors = On/g' /etc/php/5.6/cli/php.ini
   sudo: yes
 
-- name: Display Errors in /etc/php5/fpm/php.ini
-  shell: sed -i -e 's/^display_errors =.*/display_errors = On/g' /etc/php5/fpm/php.ini
+- name: Display Errors in /etc/php/5.6/fpm/php.ini
+  shell: sed -i -e 's/^display_errors =.*/display_errors = On/g' /etc/php/5.6/fpm/php.ini
   sudo: yes
 
 # Error Reporting
-- name: Error Reporting in /etc/php5/apache2/php.ini
-  shell: sed -i -e 's/^error_reporting =.*/error_reporting = E_ALL/g' /etc/php5/apache2/php.ini
+- name: Error Reporting in /etc/php/5.6/apache2/php.ini
+  shell: sed -i -e 's/^error_reporting =.*/error_reporting = E_ALL/g' /etc/php/5.6/apache2/php.ini
   sudo: yes
 
-- name: Error Reporting in /etc/php5/cli/php.ini
-  shell:  sed -i -e 's/^error_reporting =.*/error_reporting = E_ALL/g' /etc/php5/cli/php.ini
+- name: Error Reporting in //etc/php/5.6/cli/php.ini
+  shell:  sed -i -e 's/^error_reporting =.*/error_reporting = E_ALL/g' /etc/php/5.6/cli/php.ini
   sudo: yes
 
-- name: Display Errors in /etc/php5/fpm/php.ini
-  shell: sed -i -e 's/^error_reporting =.*/error_reporting = E_ALL/g' /etc/php5/fpm/php.ini
+- name: Display Errors in /etc/php/5.6/fpm/php.ini
+  shell: sed -i -e 's/^error_reporting =.*/error_reporting = E_ALL/g' /etc/php/5.6/fpm/php.ini
   sudo: yes
 
 - name: Reload all
-  shell: service php5-fpm restart && service apache2 restart
+  shell: service php5.6-fpm restart && service apache2 restart
   sudo: yes

--- a/ansible/roles/server/tasks/main.yml
+++ b/ansible/roles/server/tasks/main.yml
@@ -14,7 +14,10 @@
 - name: Install Extra Packages
   sudo: yes
   apt: pkg={{ item }} state=latest
-  with_items: server.packages
+  with_items:
+    - htop
+    - imagemagick
+    - git
   when: server.packages is defined
 
 - name: Configure the timezone
@@ -28,4 +31,3 @@
 - name: Set default system language pack
   shell: locale-gen {{server.locale}}
   sudo: yes
-

--- a/ansible/roles/xdebug/tasks/main.yml
+++ b/ansible/roles/xdebug/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Install xDebug
   sudo: yes
-  apt: pkg=php5-xdebug state=latest
+  apt: pkg=php5.6-xdebug state=latest

--- a/ansible/vars/all.yml
+++ b/ansible/vars/all.yml
@@ -1,7 +1,6 @@
 ---
 server:
     install: '1'
-    packages: [htop, imagemagick, git]
     timezone: Europe/Warsaw
     locale: pl_PL.UTF-8
 vagrant_local:
@@ -20,10 +19,8 @@ mysql:
     dump: 'dump/forum.sql'
 php:
     install: '1'
-    ppa: php5-5.6
-    packages: [php5-cli, php5-intl, php5-mcrypt, php5-curl, php5-imagick, php5-common, php5-memcache, php5-mysql, php5-readline, php5-sqlite, php5-gd]
+    ppa: php
 xdebug:
     install: '1'
 composer:
     install: '1'
-


### PR DESCRIPTION
close #58 

Testowane na:
- Linux: Mint 18
- VirtualBox: 5.1.8 r111374 (Qt5.5.1)
- Vagrant: 1.8.6

Na nowszych wersjach VB, ansible ma problem przy pobieraniu zmiennych `php.packages` i `server.packages`.

Dodatkowo poprawiłem ppa PHP.

Dodatkowo trzeba wyłączyć firewalla.