### PR TITLE
Zmiana punktowania list w postach

### DIFF
--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -1039,27 +1039,8 @@ h1 a:hover, h1 a:focus, h1 a:visited {
 	padding: 0;
 }
 .entry-content ul > li, .qa-c-item-content ul > li {
-	list-style: none;
 	margin: .4em 0;
 	position: relative;
-}
-.entry-content ul > li:before, .qa-c-item-content ul > li:before {
-	font-family: "fontello";
-	font-style: normal;
-	font-weight: normal;
-	speak: none;
-	content: '\e82c';
-	position: absolute;
-	left: -1.6em;
-	top: 4px;
-	display: inline-block;
-	text-decoration: inherit;
-	width: 1em;
-	margin: 0 .2em;
-	text-align: center;
-	font-variant: normal;
-	text-transform: none;
-	line-height: 1em;
 }
 .entry-content ul > li > ul, .qa-c-item-content ul > li > ul {
 	margin: 0 0 0 20px;


### PR DESCRIPTION
W chwili obecnej lista wypunktowana to dość dziwne ikonki, są sugestie, aby zmienić to na coś bardziej standardowego. Myślę, że nawet zwykłe kropki wyglądają lepiej.

Widok przed i po:
![Wypunktowanie](https://img.waluk.pl/6ca883)

_Podziękowania dla @sheadovas, który podesłał mi właściwie gotowe rozwiązanie i wielokrotnie przypominał o tej drobnej poprawce._