### PR TITLE
Usunięcie ikony wiadomości z linku do kategorii w przypadku ekspertów

### DIFF
--- a/forum/qa-include/pages/user-profile.php
+++ b/forum/qa-include/pages/user-profile.php
@@ -593,7 +593,7 @@
 					$qa_content['form_profile']['fields']['level']['value'] .= '<br/>'.
 						strtr(qa_lang_html('users/level_for_category'), array(
 							'^1' => $showcategorylevel,
-							'^2' => '<a href="'.qa_path_html(implode('/', array_reverse(explode('/', $userlevel['backpath'])))).'">'.qa_html($userlevel['title']).'</a>',
+							'^2' => '<a href="'.qa_path_html(implode('/', array_reverse(explode('/', $userlevel['backpath'])))).'" class="category-level-link">'.qa_html($userlevel['title']).'</a>',
 						));
 				}
 			}

--- a/forum/qa-lang/pl/qa-lang-users.php
+++ b/forum/qa-lang/pl/qa-lang-users.php
@@ -68,7 +68,7 @@
 		'level_admin' => 'Administrator',
 		'level_editor' => 'Redaktor',
 		'level_expert' => 'Ekspert',
-		'level_for_category' => "^1 na ^2",
+		'level_for_category' => "^1 w kategorii ^2",
 		'level_in_general' => "generalnie",
 		'level_moderator' => 'Moderator',
 		'level_super' => 'Superadministrator',

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4838,3 +4838,15 @@ form div.qa-q-view-content
 	border-radius: 5px;
 	padding: 0px 2px;
 }
+#level .qa-form-wide-static a.category-level-link {
+	color: #2980b9;
+	text-decoration: none;
+	background: none;
+	border: 0;
+	padding: 0;
+	font-weight: bold;
+}
+#level .qa-form-wide-static a.category-level-link:hover {
+	color: #3498db;
+	text-decoration: underline;
+}


### PR DESCRIPTION
Gdy dana osoba jest ekspertem tylko w danej kategorii na profilu widnieje o tym stosowna informacja, niestety jednak nazwa kategorii posiada ikonkę wiadomości i wygląda to tak, jakby można było wysłać wiadomość do kategorii(?).
![Kategoria przed](https://img.waluk.pl/72d64c)

Przygotowałem poprawkę, która usuwa tą dziwną stylizację linku. Ponadto pogrubiłem nazwę kategorii, aby była bardziej widoczna i zmieniłem opis "Ekspert **na** X" na "Ekspert **w kategorii** X" - wydaje mi się, że będzie to bardziej zrozumiałe.
![Kategoria po](https://img.waluk.pl/8b8d6f)