### PR TITLE
Added share button with auto copy link

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -892,7 +892,7 @@ window.initializeCopyToClipboard = ( function() {
 	if ( !!copyToClipboard ) {
 		var shareMethodPopup = ( function() {
 			var popup = document.createElement( 'div' );
-			popup.classList.add( 'share-button-popup' );
+			popup.classList.add( 'share-popup' );
             popup.id = 'share-popup';
 
 			var shareLinkField = document.createElement( 'input' );

--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -893,6 +893,7 @@ window.initializeCopyToClipboard = ( function() {
 		var shareMethodPopup = ( function() {
 			var popup = document.createElement( 'div' );
 			popup.classList.add( 'share-button-popup' );
+            popup.id = 'share-popup';
 
 			var shareLinkField = document.createElement( 'input' );
 			shareLinkField.type = 'text';
@@ -944,20 +945,23 @@ window.initializeCopyToClipboard = ( function() {
                     var topicContentGroup = eTarget.parentNode.classList[ 0 ].split( '-' )[ 2 ];
                     var olderParentRef = topicContentGroup === 'item' ? parentRef.parentNode.parentNode : parentRef.parentNode;
                     popupParentRef = parentRef;
+                    var sharePopupElem = document.getElementById( 'share-popup' );
 
-                    console.warn( 'wtf??: ', topicContentGroup, ' /grand parent: ', olderParentRef, ' />>> ', olderParentRef.querySelector( '[class*="-' + topicContentGroup + '-meta"]') );
-                    var url = olderParentRef.querySelector( '[class*="-' + topicContentGroup + '-meta"] a' ).href;
-                    console.log( 'share url: ', url );
+                    if ( !sharePopupElem ) {
+                        var url = olderParentRef.querySelector( '[class*="-' + topicContentGroup + '-meta"] a' ).href;
 
-                    shareMethodPopup.shareLinkField.value = url;
-                    parentRef.appendChild( shareMethodPopup.popup );
+                        shareMethodPopup.shareLinkField.value = url;
+                        parentRef.appendChild( shareMethodPopup.popup );
+                    } else if ( sharePopupElem ) {
+                        sharePopupElem.parentNode.removeChild( shareMethodPopup.popup );
+                    }
 				} else if ( eClassList.contains( 'copy-shared-link' ) ) {
-                    copyToClipboard( ev, location.href );
+                    var url = eTarget.previousElementSibling.value;
+
+                    copyToClipboard( ev, url );
                     popupParentRef.removeChild( shareMethodPopup.popup );
                 }
 			} );
-
-			console.info( 'buttons bar: ', allActionButtonsBar );//, ' /answers: ', document.querySelectorAll( '.qa-a-item-buttons' ), ' /comments: ', document.querySelectorAll( '.qa-c-item-buttons' ) );
 		};
 
 		document.addEventListener( 'DOMContentLoaded', addShareButton );

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4841,3 +4841,14 @@ form div.qa-q-view-content
 	color: #3498db;
 	text-decoration: underline;
 }
+
+.share-button {
+	color: green;
+	font-weight: bold;
+	padding: 5px;
+}
+
+.share-popup {
+	border: 2px solid orange;
+	display: inline-block;
+}


### PR DESCRIPTION
**Referring to:** https://github.com/CodersCommunity/forum.pasja-informatyki.local/issues/87

I created sharing button, which after clicking shows small popup that includes referred response link and copy button (it uses copy function I added few months ago in other feature - by the way I refactored `copyToClipboard` function to be globally available, so now all features can ues it).

Just for now I styled it in a simple and ugly way - too show that "it is there". If this feature will be accepted, then it will be styled of course.

I know that mentioned issue was about generating URL from server (to have user id or some other params) and maybe passing it to JS via some AJAX or other way, but I implemented all in JS. It just takes URL of topic/comment/answer, so it behaves simply. When somebody will do it at backend, then my code can be modified to take URL from server.

**Screen:** http://imgur.com/a/4vxqf