### PR TITLE
Zmiany na liście języków podczas wstawiania kodu

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -480,7 +480,7 @@ function qa_ajax_error()
 			'bash' : 'bash-shell',
 			'cf' : 'coldfusion',
 			'csharp' : 'C#',
-			'cpp' : 'C++',
+			'cpp' : 'C/C++',
 			'css' : 'CSS',
 			'delphi' : 'delphi',
 			'diff' : 'diff',
@@ -500,7 +500,6 @@ function qa_ajax_error()
 			'scala' : 'scala',
 			'sql' : 'SQL',
 			'tap' : 'tap',
-			'ts' : 'TypeScript',
 			'vb' : 'VB',
 			'xml' : 'XML-xHTML'
 		};

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/dialogs/syntaxhighlight.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/dialogs/syntaxhighlight.js
@@ -11,7 +11,7 @@ CKEDITOR.dialog.add( 'syntaxhighlightDialog', function( editor ) {
 		options.firstLine=editor.config.syntaxhighlight_firstLine;
 		options.highlightChecked=String(editor.config.syntaxhighlight_highlightChecked).toLowerCase()==='true';
 		options.highlight=editor.config.syntaxhighlight_highlight;
-		options.lang=(validLangs.indexOf(editor.config.syntaxhighlight_lang)>-1) ? editor.config.syntaxhighlight_lang : 'as3';
+		options.lang=(validLangs.indexOf(editor.config.syntaxhighlight_lang)>-1) ? editor.config.syntaxhighlight_lang : 'plain';
 		options.code=editor.config.syntaxhighlight_code;
 		return options
 	};

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/dialogs/syntaxhighlight.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/dialogs/syntaxhighlight.js
@@ -149,7 +149,7 @@ CKEDITOR.dialog.add( 'syntaxhighlightDialog', function( editor ) {
 									['Bash (Shell)','bash'],
 									['ColdFusion','cf'],
 									['C#','csharp'],
-									['C++','cpp'],
+									['C/C++','cpp'],
 									['CSS','css'],
 									['Delphi','delphi'],
 									['Diff','diff'],
@@ -169,7 +169,6 @@ CKEDITOR.dialog.add( 'syntaxhighlightDialog', function( editor ) {
 									['Scala','scala'],
 									['SQL','sql'],
 									['TAP','tap'],
-									['TypeScript','ts'],
 									['VB','vb'],
 									['XML/XHTML','xml']
 								],


### PR DESCRIPTION
Chodzi o wybór składni podczas wstawiania kodu w bloczek, przy okazji też o nazwę podczas wyświetlania.
Brakowało języka C, co prawda był C++ i raczej wiadomo było, że należy go wybrać. Jednak pojawiała się sugestia, aby dla porządku zmienić na "C/C++" i tak też zrobiłem.
Przy okazji usunąłem z listy TypeScript, a to dlatego że nigdy nie mieliśmy kolorowania składni tego języka i jego wybór kończył się później błędem podczas wyświetlania posta.