### PR TITLE
Poprawka błędu przy JSFiddle snippet

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -262,7 +262,7 @@ function qa_ajax_error()
 			jsfiddleSnippetForm.action = 'https://jsfiddle.net/api/post/library/pure/';
 			jsfiddleSnippetForm.method = 'POST';
 			jsfiddleSnippetForm.target = '_blank';
-			jsfiddleSnippetForm.classList = 'jsfiddle-snippet';
+			jsfiddleSnippetForm.classList.add('jsfiddle-snippet');
 
 			var htmlTxt = document.createElement('textarea');
 			htmlTxt.name = 'html';


### PR DESCRIPTION
https://forum.pasja-informatyki.pl/247233/linux-brak-przyciskow-do-codypena-i-jsfiddle-na-forum

Okazało się, że błędnie dodałem klasę dla formularza tworzącego snippet dla JSFiddle. Poprawione. Dziwne, że do tej pory nie było z tym problemów.