### PR TITLE
Naprawa wielokrotnego wysyłania formularza pytania

### DIFF
--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -389,7 +389,7 @@ function set_category_description(idprefix)
 // Protect from multiple ask form submit
 
 window.addEventListener('load', function() {
-	$("form").submit(function() {
+	$("#__ask-form").submit(function() {
     $(this).submit(function() {
         return false;
     });

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -385,3 +385,14 @@ function set_category_description(idprefix)
 		});
 	});
 }(document));
+
+// Protect from multiple ask form submit
+
+window.addEventListener('load', function() {
+	$("form").submit(function() {
+    $(this).submit(function() {
+        return false;
+    });
+    return true;
+});
+});

--- a/forum/qa-include/pages/ask.php
+++ b/forum/qa-include/pages/ask.php
@@ -164,7 +164,7 @@
 	$custom=qa_opt('show_custom_ask') ? trim(qa_opt('custom_ask')) : '';
 
 	$qa_content['form']=array(
-		'tags' => 'name="ask" method="post" action="'.qa_self_html().'"',
+		'tags' => 'id="__ask-form" name="ask" method="post" action="'.qa_self_html().'"',
 
 		'style' => 'tall',
 


### PR DESCRIPTION
Naprawa miała na celu ograniczyć wysyłanie klonów pytań przez wielokrotne naciśnięcie przycisku "Zadaj pytanie".