### PR TITLE
Naprawa wielokrotnego wysyłania formularzy

### DIFF
--- a/forum/qa-content/qa-forms-protection.js
+++ b/forum/qa-content/qa-forms-protection.js
@@ -1,0 +1,8 @@
+window.addEventListener('DOMContentLoaded', function()
+{
+	$("#__form").submit(function()
+	{
+		$('#__form-send').attr('disabled', true);
+		return true;
+	});
+});

--- a/forum/qa-include/pages/ask.php
+++ b/forum/qa-include/pages/ask.php
@@ -164,7 +164,7 @@
 	$custom=qa_opt('show_custom_ask') ? trim(qa_opt('custom_ask')) : '';
 
 	$qa_content['form']=array(
-		'tags' => 'name="ask" method="post" action="'.qa_self_html().'"',
+		'tags' => 'id="__form" name="ask" method="post" action="'.qa_self_html().'"',
 
 		'style' => 'tall',
 
@@ -191,7 +191,7 @@
 
 		'buttons' => array(
 			'ask' => array(
-				'tags' => 'onclick="qa_show_waiting_after(this, false); '.
+				'tags' => 'id="__form-send" onclick="qa_show_waiting_after(this, false); '.
 					(method_exists($editor, 'update_script') ? $editor->update_script('content') : '').'"',
 				'label' => qa_lang_html('question/ask_button'),
 			)/*,
@@ -280,7 +280,8 @@
 
 	$qa_content['focusid']='title';
 
-
+	$qa_content['script_rel'][] = 'qa-content/qa-forms-protection.js';
+	
 	return $qa_content;
 
 

--- a/forum/qa-include/pages/feedback.php
+++ b/forum/qa-include/pages/feedback.php
@@ -122,7 +122,7 @@
 	$qa_content['error']=@$pageerror;
 
 	$qa_content['form']=array(
-		'tags' => 'method="post" action="'.qa_self_html().'"',
+		'tags' => 'id="__form" method="post" action="'.qa_self_html().'"',
 
 		'style' => 'tall',
 
@@ -154,6 +154,7 @@
 
 		'buttons' => array(
 			'send' => array(
+				'tags' => 'id="__form-send"',
 				'label' => qa_lang_html('main/send_button'),
 			),
 		),
@@ -176,7 +177,8 @@
 		unset($qa_content['form']['buttons']);
 	}
 
-
+	$qa_content['script_rel'][] = 'qa-content/qa-forms-protection.js';
+	
 	return $qa_content;
 
 

--- a/forum/qa-include/pages/message.php
+++ b/forum/qa-include/pages/message.php
@@ -171,7 +171,7 @@
 	$qa_content['error'] = @$pageerror;
 
 	$qa_content['form_message'] = array(
-		'tags' => 'method="post" action="'.qa_self_html().'"',
+		'tags' => 'id="__form" method="post" action="'.qa_self_html().'"',
 
 		'style' => 'tall',
 
@@ -191,7 +191,7 @@
 
 		'buttons' => array(
 			'send' => array(
-				'tags' => 'onclick="qa_show_waiting_after(this, false);"',
+				'tags' => 'id="__form-send" onclick="qa_show_waiting_after(this, false);"',
 				'label' => qa_lang_html('main/send_button'),
 			),
 		),
@@ -242,6 +242,8 @@
 
 	$qa_content['raw']['account'] = $toaccount; // for plugin layers to access
 
+	$qa_content['script_rel'][] = 'qa-content/qa-forms-protection.js';
+	
 	return $qa_content;
 
 


### PR DESCRIPTION
Poprawienie PR #105 , teraz przypisywany jest atrybut disabled do przycisków wysyłających, po jednokrotnym ich wciśnięciu.