### PR TITLE
Dodanie tła dla bloczku kodu w trybie edycji

### DIFF
--- a/forum/qa-plugin/ckeditor4/contents.css
+++ b/forum/qa-plugin/ckeditor4/contents.css
@@ -98,6 +98,7 @@ pre
 	word-wrap: break-word; /* IE7 */
 	-moz-tab-size: 4;
 	tab-size: 4;
+	background-color: #ffffaa;
 }
 
 .marker

--- a/forum/qa-plugin/ckeditor4/contents.css
+++ b/forum/qa-plugin/ckeditor4/contents.css
@@ -98,7 +98,8 @@ pre
 	word-wrap: break-word; /* IE7 */
 	-moz-tab-size: 4;
 	tab-size: 4;
-	background-color: #ffffaa;
+	background-color: #ffffbb;
+	padding: 10px;
 }
 
 .marker


### PR DESCRIPTION
Dodałem pastelowe tło dla bloczku kodu źródłowego w edytorze. Moim zdaniem wcześniejsze wyróżnienie (niezbyt widoczna zmiana czcionki) było nieco mylące dla nowych użytkowników, no i przez to można było zauważyć wiele postów z treścią pytania wrzuconą do kodu źródłowego.

Oto rezultat.

![image](https://user-images.githubusercontent.com/15708308/36166976-8dc979cc-10f4-11e8-90c8-ee8e3e9ddba4.png)
