### PR TITLE
Język polski w SyntaxHighlighterze

### DIFF
--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/lang/pl.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/lang/pl.js
@@ -11,7 +11,7 @@ CKEDITOR.plugins.setLang('syntaxhighlight', 'pl', {
 	hideControlsLbl:'Ukryj dodatkowe informacje na górze bloczka z kodem.',
 	collapse:'Blokowanie',
 	collapseLbl:'Domyślnie zablokuj blok kodu (dodatkowe informacje muszą być włączone',
-	codeTitleLbl:'Użyj tytuł bloku',
+	codeTitleLbl:'Tytuł bloku',
 	showColumns:'Pokaż kolumny',
 	showColumnsLbl:'Pokaż rząd kolumn w pierwszej linii',
 	lineWrap:'Wyłącz liniowe zawijanie bloku',

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/lang/pl.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/lang/pl.js
@@ -1,0 +1,22 @@
+CKEDITOR.plugins.setLang('syntaxhighlight', 'pl', {
+	title:'Dodaj lub zaktualizuj bloczek kodu',
+	contextTitle:'Edytuj kod źródłowy',
+	sourceTab:'Kod źródłowy',
+	langLbl:'Wybierz język',
+	sourceTextareaEmptyError:'Kod źródłowy nie może być pusty!',
+	advancedTab:'Zaawansowane',
+	hideGutter:'Ukryj język',
+	hideGutterLbl:'Ukryj język i numery linii',
+	hideControls:'Ukryj informacje',
+	hideControlsLbl:'Ukryj dodatkowe informacje na górze bloczka z kodem.',
+	collapse:'Blokowanie',
+	collapseLbl:'Domyślnie zablokuj blok kodu (dodatkowe informacje muszą być włączone',
+	codeTitleLbl:'Użyj tytuł bloku',
+	showColumns:'Pokaż kolumny',
+	showColumnsLbl:'Pokaż rząd kolumn w pierwszej linii',
+	lineWrap:'Wyłącz liniowe zawijanie bloku',
+	lineWrapLbl:'Wyłącz liniowe zawijanie bloku',
+	lineCount:'Domyślna liczba linii',
+	highlight:'Podświetl linie',
+	highlightLbl:'Wpisz linie które chcesz podświetlić (oddziel je przecinkiem) np.<em style="font-style:italic">3,10,15</em>.'
+});

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/plugin.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/plugin.js
@@ -1,6 +1,6 @@
 ﻿CKEDITOR.plugins.add( 'syntaxhighlight', {
 	requires : 'dialog',
-	lang : 'en,de,fr,zh-cn', // %REMOVE_LINE_CORE%
+	lang : 'pl', // %REMOVE_LINE_CORE%
 	icons : 'syntaxhighlight', // %REMOVE_LINE_CORE%
 	init : function( editor ) {
 		editor.addCommand( 'syntaxhighlightDialog', new CKEDITOR.dialogCommand( 'syntaxhighlightDialog', {


### PR DESCRIPTION
Cały edytor jest spolszczony z wyjątkiem bloczka code, który jest po angielsku. Poprawka wprowadza nowy plik (pl.js) z tłumaczeniami (możliwe, że wkradł się jakiś błąd - robiłem to dosyć szybko. Jeżeli taki błąd się wkradł na pewno to poprawię) oraz zmieniony plik konfiguracyjny, w którym możliwym językiem jest tylko język polski. 