### PR TITLE
Inteligentny bloczek CODE

### DIFF
--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -25,7 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
                         });
 	                 
                             CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
-		            } else {		
+		    } else {		
                             CKEDITOR.config.syntaxhighlight_lang = 'plain';		
                     }
                      		
@@ -34,21 +34,20 @@ document.addEventListener("DOMContentLoaded", () => {
            } else if ( location.href.includes( 'edit' ) ) {
                 clickHandler = () => {
 	               			
+                    let findCategory;	
                     const firstCategory = document.querySelector( '#q_category_1' );
-                    if(firstCategory != undefined)
-                    {
+                    if(firstCategory) {
                         const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
-                        if(selectedFirstOption.textContent === 'Programowanie') 
-                        {
+						if(selectedFirstOption.textContent === 'Programowanie') {
                             const secondCategory = document.querySelector( '#q_category_2' );
                             const selectedSecondOption = secondCategory.children[ secondCategory.selectedIndex ];
-                            var findCategory = categories.find( function(object) {
+                            findCategory = categories.find( ( object ) => {
                                 return object.category == selectedSecondOption.textContent;
                             });
                         }
                     } else {
                        const category = document.querySelector( '.qa-q-view-where-data' );
-                       var findCategory = categories.find( function(object) {
+                       findCategory = categories.find( ( object ) => {
                             return object.category == category.textContent;
                         });
                     }

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", function(event) {
+document.addEventListener("DOMContentLoaded", () => {
     if (typeof CKEDITOR != 'undefined') {
         CKEDITOR.on( 'instanceReady', function() {
             const categories = [
@@ -15,12 +15,13 @@ document.addEventListener("DOMContentLoaded", function(event) {
 		
             if ( location.href.includes( '/ask' ) ) {
                 codeBlock.addEventListener( 'click', () => {
-                    const firstCategory = $( '#category_1 option:selected' );
-                       	
-                    if(firstCategory.text() === 'Programowanie') {
-                        const secondCategory = $( '#category_2 option:selected' );			
+                    const firstCategory = document.querySelector( '#category_1' );
+                    const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
+                    if(selectedFirstOption.textContent === 'Programowanie') {
+                        const firstCategory = document.querySelector( '#category_2' );
+                        const selectedSecondOption = firstCategory.children[ firstCategory.selectedIndex ];			
                         const findCategory = categories.find( function(object) {
-                            return object.category == secondCategory.text();
+                            return object.category == selectedSecondOption.textContent;
                         });
                             			
                         if(findCategory != undefined){
@@ -29,6 +30,10 @@ document.addEventListener("DOMContentLoaded", function(event) {
                             CKEDITOR.config.syntaxhighlight_lang = 'plain';
                         }
 	                 
+		    } else {
+						
+                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
+						
                     }
                      		
                 });
@@ -36,11 +41,12 @@ document.addEventListener("DOMContentLoaded", function(event) {
             } else if ( location.href.includes( 'edit' ) ) {
                 codeBlock.addEventListener( 'click', () => {
 	               			
-                    const questionEditFirstCategory = $( '#q_category_1 option:selected' );
-                    if(questionEditFirstCategory.text() === 'Programowanie'){
-                        const questionEditSecondCategory = $( '#q_category_2 option:selected' );
+                    const firstCategory = document.querySelector( '#q_category_1' );
+                    const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
+                    if(selectedFirstOption.textContent === 'Programowanie') {
+                        const secondCategory = document.querySelector( '#q_category_2' );
                         const findCategory = categories.find( function(object) {
-                            return object.category == questionEditSecondCategory.text();
+                            return object.category == secondCategory.textContent;
                         });
 		            
                         if(findCategory != undefined){
@@ -48,15 +54,19 @@ document.addEventListener("DOMContentLoaded", function(event) {
                         } else {
                             CKEDITOR.config.syntaxhighlight_lang = 'plain';
                         }
+                    } else {
+						
+                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
+						
                     }
                 });
 	        		
 	    } else {
                 codeBlock.addEventListener( 'click', () => {
 				
-                    const category = $( '.qa-q-view-where-data' );
+                    const category = document.querySelector( '.qa-q-view-where-data' );
                     const findCategory = categories.find( function(object) {
-                        return object.category == category.text();
+                        return object.category == category.textContent;
                     });
 		     	
                     if(findCategory != undefined){
@@ -69,4 +79,4 @@ document.addEventListener("DOMContentLoaded", function(event) {
             }		   
         });
     }
-}
+});

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -1,76 +1,73 @@
 CKEDITOR.on( "instanceReady", function() {
-	const codeBlock = document.getElementById( "cke_43" );
+    const codeBlock = document.getElementById( "cke_43" );
     if ( location.href.includes( "/ask" ) ) {
-		codeBlock.addEventListener( "click", function() {
-		    const category_1 = $('#category_1 option:selected');
-			if(category_1.text() === 'Programowanie'){
-				const category_2 = $('#category_2 option:selected');
-				
-				switch(category_2.text()){
-					case 'HTML i CSS':
-						CKEDITOR.config.syntaxhighlight_lang = 'plain';
-					break;
-					case 'C i C++':
-						CKEDITOR.config.syntaxhighlight_lang = 'cpp';
-					break;
-					case 'JavaScript, jQuery, AJAX':
-						CKEDITOR.config.syntaxhighlight_lang = 'jscript';
-					break;
-					case 'PHP, Symfony, Zend':
-						CKEDITOR.config.syntaxhighlight_lang = 'php';
-					break;
-					case 'SQL, bazy danych':
-						CKEDITOR.config.syntaxhighlight_lang = 'sql';
-					break;
-					case 'C# i .NET':
-						CKEDITOR.config.syntaxhighlight_lang = 'csharp';
-					break;
-					case 'Java':
-						CKEDITOR.config.syntaxhighlight_lang = 'java';
-					break;
-					case 'Python, Django':
-						CKEDITOR.config.syntaxhighlight_lang = 'python';
-					break;
-					default:
-						CKEDITOR.config.syntaxhighlight_lang = 'plain';
-					break;
-				}				
-			}
-		});
-	} else {
-		codeBlock.addEventListener( 'click', function() {
-			const category = $('.qa-q-view-where-data').text();
-			alert(category);
-			switch(category){
-				case 'HTML i CSS':
-						CKEDITOR.config.syntaxhighlight_lang = 'xml';
-					break;
-					case 'C i C++':
-						CKEDITOR.config.syntaxhighlight_lang = 'cpp';
-					break;
-					case 'JavaScript, jQuery, AJAX':
-						CKEDITOR.config.syntaxhighlight_lang = 'jscript';
-					break;
-					case 'PHP, Symfony, Zend':
-						CKEDITOR.config.syntaxhighlight_lang = 'php';
-					break;
-					case 'SQL, bazy danych':
-						CKEDITOR.config.syntaxhighlight_lang = 'sql';
-					break;
-					case 'C# i .NET':
-						CKEDITOR.config.syntaxhighlight_lang = 'csharp';
-					break;
-					case 'Java':
-						CKEDITOR.config.syntaxhighlight_lang = 'java';
-					break;
-					case 'Python, Django':
-						CKEDITOR.config.syntaxhighlight_lang = 'python';
-					break;
-					default:
-						CKEDITOR.config.syntaxhighlight_lang = 'plain';
-					break;
-			}
-		});
-	}
- 		   
+        codeBlock.addEventListener( "click", function() {
+            const category_1 = $('#category_1 option:selected');
+            if(category_1.text() === 'Programowanie') {
+                const category_2 = $('#category_2 option:selected');			
+                switch(category_2.text()){
+                    case 'HTML i CSS':
+                        CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                    break;
+                    case 'C i C++':
+                        CKEDITOR.config.syntaxhighlight_lang = 'cpp';
+                    break;
+                    case 'JavaScript, jQuery, AJAX':
+                        CKEDITOR.config.syntaxhighlight_lang = 'jscript';
+                    break;
+                    case 'PHP, Symfony, Zend':
+                        CKEDITOR.config.syntaxhighlight_lang = 'php';
+                    break;
+                    case 'SQL, bazy danych':
+                        CKEDITOR.config.syntaxhighlight_lang = 'sql';
+                    break;
+                    case 'C# i .NET':
+                        CKEDITOR.config.syntaxhighlight_lang = 'csharp';
+                    break;
+                    case 'Java':
+                        CKEDITOR.config.syntaxhighlight_lang = 'java';
+                    break;
+                    case 'Python, Django':
+                        CKEDITOR.config.syntaxhighlight_lang = 'python';
+                    break;
+                    default:
+                        CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                    break;
+                }    			
+            }    
+        });
+    } else {
+        codeBlock.addEventListener( 'click', function() {
+            const category = $('.qa-q-view-where-data').text();
+            switch(category){
+                case 'HTML i CSS':
+                    CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                break;
+                case 'C i C++':
+                    CKEDITOR.config.syntaxhighlight_lang = 'cpp';
+                break;
+                case 'JavaScript, jQuery, AJAX':
+                    CKEDITOR.config.syntaxhighlight_lang = 'jscript';
+                break;
+                case 'PHP, Symfony, Zend':
+                    CKEDITOR.config.syntaxhighlight_lang = 'php';
+                break;
+                case 'SQL, bazy danych':
+                    CKEDITOR.config.syntaxhighlight_lang = 'sql';
+                break;
+                case 'C# i .NET':
+                    CKEDITOR.config.syntaxhighlight_lang = 'csharp';
+                break;
+                case 'Java':
+                    CKEDITOR.config.syntaxhighlight_lang = 'java';
+                break;
+                case 'Python, Django':
+                    CKEDITOR.config.syntaxhighlight_lang = 'python';
+                break;
+                default:
+                    CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                break;
+            }   
+        });
+    }		   
 });

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -7,7 +7,7 @@ CKEDITOR.on( "instanceReady", function() {
                 const category_2 = $('#category_2 option:selected');			
                 switch(category_2.text()){
                     case 'HTML i CSS':
-                        CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                        CKEDITOR.config.syntaxhighlight_lang = 'xml';
                     break;
                     case 'C i C++':
                         CKEDITOR.config.syntaxhighlight_lang = 'cpp';
@@ -36,12 +36,48 @@ CKEDITOR.on( "instanceReady", function() {
                 }    			
             }    
         });
-    } else {
+    } else if ( location.href.includes( "edit" ) ) {
+            codeBlock.addEventListener( "click", function() {
+            const questionEditCategory_1 = $('#q_category_1 option:selected');
+            if(questionEditCategory_1.text() === 'Programowanie'){
+                const questionEditCategory_2 = $('#q_category_2 option:selected');
+				switch(category_2.text()){
+                    case 'HTML i CSS':
+                        CKEDITOR.config.syntaxhighlight_lang = 'xml';
+                    break;
+                    case 'C i C++':
+                        CKEDITOR.config.syntaxhighlight_lang = 'cpp';
+                    break;
+                    case 'JavaScript, jQuery, AJAX':
+                        CKEDITOR.config.syntaxhighlight_lang = 'jscript';
+                    break;
+                    case 'PHP, Symfony, Zend':
+                        CKEDITOR.config.syntaxhighlight_lang = 'php';
+                    break;
+                    case 'SQL, bazy danych':
+                        CKEDITOR.config.syntaxhighlight_lang = 'sql';
+                    break;
+                    case 'C# i .NET':
+                        CKEDITOR.config.syntaxhighlight_lang = 'csharp';
+                    break;
+                    case 'Java':
+                        CKEDITOR.config.syntaxhighlight_lang = 'java';
+                    break;
+                    case 'Python, Django':
+                        CKEDITOR.config.syntaxhighlight_lang = 'python';
+                    break;
+                    default:
+                        CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                    break;
+                }   		
+            }
+        });
+	} else {
         codeBlock.addEventListener( 'click', function() {
             const category = $('.qa-q-view-where-data').text();
             switch(category){
                 case 'HTML i CSS':
-                    CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                    CKEDITOR.config.syntaxhighlight_lang = 'xml';
                 break;
                 case 'C i C++':
                     CKEDITOR.config.syntaxhighlight_lang = 'cpp';

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -23,17 +23,10 @@ document.addEventListener("DOMContentLoaded", () => {
                         const findCategory = categories.find( function(object) {
                             return object.category == selectedSecondOption.textContent;
                         });
-                            			
-                        if(findCategory != undefined){
-                            CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-                        } else { 
-                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
-                        }
 	                 
-		    } else {
-						
-                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
-						
+                            CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
+		    } else {		
+                            CKEDITOR.config.syntaxhighlight_lang = 'plain';		
                     }
                      		
                 });
@@ -49,15 +42,9 @@ document.addEventListener("DOMContentLoaded", () => {
                             return object.category == secondCategory.textContent;
                         });
 		            
-                        if(findCategory != undefined){
-                            CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-                        } else {
-                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
-                        }
-                    } else {
-						
-                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
-						
+                            CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
+                    } else {		
+                            CKEDITOR.config.syntaxhighlight_lang = 'plain';			
                     }
                 });
 	        		
@@ -69,11 +56,7 @@ document.addEventListener("DOMContentLoaded", () => {
                         return object.category == category.textContent;
                     });
 		     	
-                    if(findCategory != undefined){
-                        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-                    } else {
-                        CKEDITOR.config.syntaxhighlight_lang = 'plain';
-                    }
+                   CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
 				
                 });
             }		   

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -41,7 +41,7 @@ CKEDITOR.on( "instanceReady", function() {
             const questionEditCategory_1 = $('#q_category_1 option:selected');
             if(questionEditCategory_1.text() === 'Programowanie'){
                 const questionEditCategory_2 = $('#q_category_2 option:selected');
-				switch(category_2.text()){
+                switch(questionEditCategory_2.text()){
                     case 'HTML i CSS':
                         CKEDITOR.config.syntaxhighlight_lang = 'xml';
                     break;

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -16,54 +16,54 @@ document.addEventListener("DOMContentLoaded", function(event) {
             if ( location.href.includes( '/ask' ) ) {
                 codeBlock.addEventListener( 'click', () => {
                     const firstCategory = $( '#category_1 option:selected' );
-				
+                       	
                     if(firstCategory.text() === 'Programowanie') {
                         const secondCategory = $( '#category_2 option:selected' );			
-					    const findCategory = categories.find( function(object) {
+                        const findCategory = categories.find( function(object) {
                             return object.category == secondCategory.text();
                         });
-					
-				        if(findCategory != undefined){
-					        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-				        } else {
-						    CKEDITOR.config.syntaxhighlight_lang = 'plain';
-					    }
-			
+                            			
+                        if(findCategory != undefined){
+                            CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+                        } else { 
+                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                        }
+	                 
                     }
-				
-			    });
-			
-		    } else if ( location.href.includes( 'edit' ) ) {
+                     		
+                });
+	         	
+            } else if ( location.href.includes( 'edit' ) ) {
                 codeBlock.addEventListener( 'click', () => {
-					
+	               			
                     const questionEditFirstCategory = $( '#q_category_1 option:selected' );
                     if(questionEditFirstCategory.text() === 'Programowanie'){
                         const questionEditSecondCategory = $( '#q_category_2 option:selected' );
-                	    const findCategory = categories.find( function(object) {
+                        const findCategory = categories.find( function(object) {
                             return object.category == questionEditSecondCategory.text();
                         });
-			
-        			    if(findCategory != undefined){
-				            CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-				        } else {
-				            CKEDITOR.config.syntaxhighlight_lang = 'plain';
-				        }
+		            
+                        if(findCategory != undefined){
+                            CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+                        } else {
+                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                        }
                     }
                 });
-				
-	        } else {
+	        		
+	    } else {
                 codeBlock.addEventListener( 'click', () => {
 				
                     const category = $( '.qa-q-view-where-data' );
-			        const findCategory = categories.find( function(object) {
+                    const findCategory = categories.find( function(object) {
                         return object.category == category.text();
                     });
-				
-				    if(findCategory != undefined){
-				        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-				    } else {
-					    CKEDITOR.config.syntaxhighlight_lang = 'plain';
-				    }
+		     	
+                    if(findCategory != undefined){
+                        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+                    } else {
+                        CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                    }
 				
                 });
             }		   

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -18,8 +18,8 @@ document.addEventListener("DOMContentLoaded", () => {
                     const firstCategory = document.querySelector( '#category_1' );
                     const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
                     if(selectedFirstOption.textContent === 'Programowanie') {
-                        const firstCategory = document.querySelector( '#category_2' );
-                        const selectedSecondOption = firstCategory.children[ firstCategory.selectedIndex ];			
+                        const secondCategory = document.querySelector( '#category_2' );
+                        const selectedSecondOption = firstCategory.children[ secondCategory.selectedIndex ];			
                         const findCategory = categories.find( function(object) {
                             return object.category == selectedSecondOption.textContent;
                         });

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -14,58 +14,58 @@ document.addEventListener("DOMContentLoaded", function(event) {
             const codeBlock = document.getElementById( 'cke_43' );
 		
             if ( location.href.includes( '/ask' ) ) {
-                    codeBlock.addEventListener( 'click', () => {
-                        const firstCategory = $( '#category_1 option:selected' );
+                codeBlock.addEventListener( 'click', () => {
+                    const firstCategory = $( '#category_1 option:selected' );
 				
-                        if(firstCategory.text() === 'Programowanie') {
-                            const secondCategory = $( '#category_2 option:selected' );			
-			    const findCategory = categories.find( function(object) {
-                                return object.category == secondCategory.text();
-                            });
-					
-                            if(findCategory != undefined){
-                                CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-                            } else {
-                                CKEDITOR.config.syntaxhighlight_lang = 'plain';
-                            }
-			
-                        }
-				
-	            });
-			
-	    } else if ( location.href.includes( 'edit' ) ) {
-                        codeBlock.addEventListener( 'click', () => {
-					
-                            const questionEditFirstCategory = $( '#q_category_1 option:selected' );
-                            if(questionEditFirstCategory.text() === 'Programowanie'){
-                                const questionEditSecondCategory = $( '#q_category_2 option:selected' );
-                	        const findCategory = categories.find( function(object) {
-                                    return object.category == questionEditSecondCategory.text();
-                                });
-			
-                        	if(findCategory != undefined){
-				    CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-				} else {
-				    CKEDITOR.config.syntaxhighlight_lang = 'plain';
-				}
-                            }    
+                    if(firstCategory.text() === 'Programowanie') {
+                        const secondCategory = $( '#category_2 option:selected' );			
+					    const findCategory = categories.find( function(object) {
+                            return object.category == secondCategory.text();
                         });
+					
+				        if(findCategory != undefined){
+					        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+				        } else {
+						    CKEDITOR.config.syntaxhighlight_lang = 'plain';
+					    }
+			
+                    }
+				
+			    });
+			
+		    } else if ( location.href.includes( 'edit' ) ) {
+                codeBlock.addEventListener( 'click', () => {
+					
+                    const questionEditFirstCategory = $( '#q_category_1 option:selected' );
+                    if(questionEditFirstCategory.text() === 'Programowanie'){
+                        const questionEditSecondCategory = $( '#q_category_2 option:selected' );
+                	    const findCategory = categories.find( function(object) {
+                            return object.category == questionEditSecondCategory.text();
+                        });
+			
+        			    if(findCategory != undefined){
+				            CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+				        } else {
+				            CKEDITOR.config.syntaxhighlight_lang = 'plain';
+				        }
+                    }
+                });
 				
 	        } else {
-                    codeBlock.addEventListener( 'click', () => {
+                codeBlock.addEventListener( 'click', () => {
 				
-                        const category = $( '.qa-q-view-where-data' );
-			const findCategory = categories.find( function(object) {
-                            return object.category == category.text();
-                        });
+                    const category = $( '.qa-q-view-where-data' );
+			        const findCategory = categories.find( function(object) {
+                        return object.category == category.text();
+                    });
 				
-			if(findCategory != undefined){
-			    CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-			} else {
-			    CKEDITOR.config.syntaxhighlight_lang = 'plain';
-			}
+				    if(findCategory != undefined){
+				        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+				    } else {
+					    CKEDITOR.config.syntaxhighlight_lang = 'plain';
+				    }
 				
-                     });
+                });
             }		   
         });
     }

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -1,47 +1,82 @@
-CKEDITOR.on( "instanceReady", function() {
-    const codeBlock = document.getElementById( "cke_43" );
-    if ( location.href.includes( "/ask" ) ) {
-        codeBlock.addEventListener( "click", function() {
-            const category_1 = $('#category_1 option:selected');
-            if(category_1.text() === 'Programowanie') {
-                const category_2 = $('#category_2 option:selected');			
-                switch(category_2.text()){
-                    case 'HTML i CSS':
-                        CKEDITOR.config.syntaxhighlight_lang = 'xml';
-                    break;
-                    case 'C i C++':
-                        CKEDITOR.config.syntaxhighlight_lang = 'cpp';
-                    break;
-                    case 'JavaScript, jQuery, AJAX':
-                        CKEDITOR.config.syntaxhighlight_lang = 'jscript';
-                    break;
-                    case 'PHP, Symfony, Zend':
-                        CKEDITOR.config.syntaxhighlight_lang = 'php';
-                    break;
-                    case 'SQL, bazy danych':
-                        CKEDITOR.config.syntaxhighlight_lang = 'sql';
-                    break;
-                    case 'C# i .NET':
-                        CKEDITOR.config.syntaxhighlight_lang = 'csharp';
-                    break;
-                    case 'Java':
-                        CKEDITOR.config.syntaxhighlight_lang = 'java';
-                    break;
-                    case 'Python, Django':
-                        CKEDITOR.config.syntaxhighlight_lang = 'python';
-                    break;
-                    default:
-                        CKEDITOR.config.syntaxhighlight_lang = 'plain';
-                    break;
-                }    			
-            }    
-        });
-    } else if ( location.href.includes( "edit" ) ) {
+if (typeof CKEDITOR != 'undefined') {
+    CKEDITOR.on( "instanceReady", function() {
+        const codeBlock = document.getElementById( "cke_43" );
+        if ( location.href.includes( "/ask" ) ) {
             codeBlock.addEventListener( "click", function() {
-            const questionEditCategory_1 = $('#q_category_1 option:selected');
-            if(questionEditCategory_1.text() === 'Programowanie'){
-                const questionEditCategory_2 = $('#q_category_2 option:selected');
-                switch(questionEditCategory_2.text()){
+                const category_1 = $('#category_1 option:selected');
+                if(category_1.text() === 'Programowanie') {
+                    const category_2 = $('#category_2 option:selected');			
+                    switch(category_2.text()){
+                        case 'HTML i CSS':
+                            CKEDITOR.config.syntaxhighlight_lang = 'xml';
+                        break;
+                        case 'C i C++':
+                            CKEDITOR.config.syntaxhighlight_lang = 'cpp';
+                        break;
+                        case 'JavaScript, jQuery, AJAX':
+                            CKEDITOR.config.syntaxhighlight_lang = 'jscript';
+                        break;
+                        case 'PHP, Symfony, Zend':
+                            CKEDITOR.config.syntaxhighlight_lang = 'php';
+                        break;
+                        case 'SQL, bazy danych':
+                            CKEDITOR.config.syntaxhighlight_lang = 'sql';
+                        break;
+                        case 'C# i .NET':
+                            CKEDITOR.config.syntaxhighlight_lang = 'csharp';
+                        break;
+                        case 'Java':
+                            CKEDITOR.config.syntaxhighlight_lang = 'java';
+                        break;
+                        case 'Python, Django':
+                            CKEDITOR.config.syntaxhighlight_lang = 'python';
+                        break;
+                        default:
+                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                        break;
+                    }    			
+                }    
+            });
+        } else if ( location.href.includes( "edit" ) ) {
+                codeBlock.addEventListener( "click", function() {
+                const questionEditCategory_1 = $('#q_category_1 option:selected');
+                if(questionEditCategory_1.text() === 'Programowanie'){
+                    const questionEditCategory_2 = $('#q_category_2 option:selected');
+                    switch(questionEditCategory_2.text()){
+                        case 'HTML i CSS':
+                            CKEDITOR.config.syntaxhighlight_lang = 'xml';
+                        break;
+                        case 'C i C++':
+                            CKEDITOR.config.syntaxhighlight_lang = 'cpp';
+                        break;
+                        case 'JavaScript, jQuery, AJAX':
+                            CKEDITOR.config.syntaxhighlight_lang = 'jscript';
+                        break;
+                        case 'PHP, Symfony, Zend':
+                            CKEDITOR.config.syntaxhighlight_lang = 'php';
+                        break;
+                        case 'SQL, bazy danych':
+                            CKEDITOR.config.syntaxhighlight_lang = 'sql';
+                        break;
+                        case 'C# i .NET':
+                            CKEDITOR.config.syntaxhighlight_lang = 'csharp';
+                        break;
+                        case 'Java':
+                            CKEDITOR.config.syntaxhighlight_lang = 'java';
+                        break;
+                        case 'Python, Django':
+                            CKEDITOR.config.syntaxhighlight_lang = 'python';
+                        break;
+                        default:
+                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                        break;
+                    }   		
+                }
+            });
+	    } else {
+            codeBlock.addEventListener( 'click', function() {
+                const category = $('.qa-q-view-where-data').text();
+                switch(category){
                     case 'HTML i CSS':
                         CKEDITOR.config.syntaxhighlight_lang = 'xml';
                     break;
@@ -69,41 +104,8 @@ CKEDITOR.on( "instanceReady", function() {
                     default:
                         CKEDITOR.config.syntaxhighlight_lang = 'plain';
                     break;
-                }   		
-            }
-        });
-	} else {
-        codeBlock.addEventListener( 'click', function() {
-            const category = $('.qa-q-view-where-data').text();
-            switch(category){
-                case 'HTML i CSS':
-                    CKEDITOR.config.syntaxhighlight_lang = 'xml';
-                break;
-                case 'C i C++':
-                    CKEDITOR.config.syntaxhighlight_lang = 'cpp';
-                break;
-                case 'JavaScript, jQuery, AJAX':
-                    CKEDITOR.config.syntaxhighlight_lang = 'jscript';
-                break;
-                case 'PHP, Symfony, Zend':
-                    CKEDITOR.config.syntaxhighlight_lang = 'php';
-                break;
-                case 'SQL, bazy danych':
-                    CKEDITOR.config.syntaxhighlight_lang = 'sql';
-                break;
-                case 'C# i .NET':
-                    CKEDITOR.config.syntaxhighlight_lang = 'csharp';
-                break;
-                case 'Java':
-                    CKEDITOR.config.syntaxhighlight_lang = 'java';
-                break;
-                case 'Python, Django':
-                    CKEDITOR.config.syntaxhighlight_lang = 'python';
-                break;
-                default:
-                    CKEDITOR.config.syntaxhighlight_lang = 'plain';
-                break;
-            }   
-        });
-    }		   
-});
+                }   
+            });
+        }		   
+    });
+}

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -1,0 +1,76 @@
+CKEDITOR.on( "instanceReady", function() {
+	const codeBlock = document.getElementById( "cke_43" );
+    if ( location.href.includes( "/ask" ) ) {
+		codeBlock.addEventListener( "click", function() {
+		    const category_1 = $('#category_1 option:selected');
+			if(category_1.text() === 'Programowanie'){
+				const category_2 = $('#category_2 option:selected');
+				
+				switch(category_2.text()){
+					case 'HTML i CSS':
+						CKEDITOR.config.syntaxhighlight_lang = 'plain';
+					break;
+					case 'C i C++':
+						CKEDITOR.config.syntaxhighlight_lang = 'cpp';
+					break;
+					case 'JavaScript, jQuery, AJAX':
+						CKEDITOR.config.syntaxhighlight_lang = 'jscript';
+					break;
+					case 'PHP, Symfony, Zend':
+						CKEDITOR.config.syntaxhighlight_lang = 'php';
+					break;
+					case 'SQL, bazy danych':
+						CKEDITOR.config.syntaxhighlight_lang = 'sql';
+					break;
+					case 'C# i .NET':
+						CKEDITOR.config.syntaxhighlight_lang = 'csharp';
+					break;
+					case 'Java':
+						CKEDITOR.config.syntaxhighlight_lang = 'java';
+					break;
+					case 'Python, Django':
+						CKEDITOR.config.syntaxhighlight_lang = 'python';
+					break;
+					default:
+						CKEDITOR.config.syntaxhighlight_lang = 'plain';
+					break;
+				}				
+			}
+		});
+	} else {
+		codeBlock.addEventListener( 'click', function() {
+			const category = $('.qa-q-view-where-data').text();
+			alert(category);
+			switch(category){
+				case 'HTML i CSS':
+						CKEDITOR.config.syntaxhighlight_lang = 'xml';
+					break;
+					case 'C i C++':
+						CKEDITOR.config.syntaxhighlight_lang = 'cpp';
+					break;
+					case 'JavaScript, jQuery, AJAX':
+						CKEDITOR.config.syntaxhighlight_lang = 'jscript';
+					break;
+					case 'PHP, Symfony, Zend':
+						CKEDITOR.config.syntaxhighlight_lang = 'php';
+					break;
+					case 'SQL, bazy danych':
+						CKEDITOR.config.syntaxhighlight_lang = 'sql';
+					break;
+					case 'C# i .NET':
+						CKEDITOR.config.syntaxhighlight_lang = 'csharp';
+					break;
+					case 'Java':
+						CKEDITOR.config.syntaxhighlight_lang = 'java';
+					break;
+					case 'Python, Django':
+						CKEDITOR.config.syntaxhighlight_lang = 'python';
+					break;
+					default:
+						CKEDITOR.config.syntaxhighlight_lang = 'plain';
+					break;
+			}
+		});
+	}
+ 		   
+});

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -31,22 +31,28 @@ document.addEventListener("DOMContentLoaded", () => {
                      		
                 };
 	         	
-            } else if ( location.href.includes( 'edit' ) ) {
+           } else if ( location.href.includes( 'edit' ) ) {
                 clickHandler = () => {
 	               			
                     const firstCategory = document.querySelector( '#q_category_1' );
-                    const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
-                    if(selectedFirstOption.textContent === 'Programowanie') {
-                        const secondCategory = document.querySelector( '#q_category_2' );
-                        const selectedSecondOption = secondCategory.children[ secondCategory.selectedIndex ];
-                        const findCategory = categories.find( function(object) {
-                            return object.category == selectedSecondOption.textContent;
+                    if(firstCategory != undefined)
+                    {
+                        const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
+                        if(selectedFirstOption.textContent === 'Programowanie') 
+                        {
+                            const secondCategory = document.querySelector( '#q_category_2' );
+                            const selectedSecondOption = secondCategory.children[ secondCategory.selectedIndex ];
+                            var findCategory = categories.find( function(object) {
+                                return object.category == selectedSecondOption.textContent;
+                            });
+                        }
+                    } else {
+                       const category = document.querySelector( '.qa-q-view-where-data' );
+                       var findCategory = categories.find( function(object) {
+                            return object.category == category.textContent;
                         });
-		            
-                            CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
-                    } else {		
-                            CKEDITOR.config.syntaxhighlight_lang = 'plain';			
                     }
+                    CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
                 };
 	        		
 	    } else {

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -14,58 +14,58 @@ document.addEventListener("DOMContentLoaded", function(event) {
             const codeBlock = document.getElementById( 'cke_43' );
 		
             if ( location.href.includes( '/ask' ) ) {
-                codeBlock.addEventListener( 'click', () => {
-                    const firstCategory = $( '#category_1 option:selected' );
+                    codeBlock.addEventListener( 'click', () => {
+                        const firstCategory = $( '#category_1 option:selected' );
 				
-                    if(firstCategory.text() === 'Programowanie') {
-                        const secondCategory = $( '#category_2 option:selected' );			
-					    const findCategory = categories.find( function(object) {
-                            return object.category == secondCategory.text();
-                        });
+                        if(firstCategory.text() === 'Programowanie') {
+                            const secondCategory = $( '#category_2 option:selected' );			
+			    const findCategory = categories.find( function(object) {
+                                return object.category == secondCategory.text();
+                            });
 					
-				        if(findCategory != undefined){
-					        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-				        } else {
-						    CKEDITOR.config.syntaxhighlight_lang = 'plain';
-					    }
+                            if(findCategory != undefined){
+                                CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+                            } else {
+                                CKEDITOR.config.syntaxhighlight_lang = 'plain';
+                            }
 			
-                    }
+                        }
 				
-			    });
+	            });
 			
-		    } else if ( location.href.includes( 'edit' ) ) {
-                codeBlock.addEventListener( 'click', () => {
+	    } else if ( location.href.includes( 'edit' ) ) {
+                        codeBlock.addEventListener( 'click', () => {
 					
-                    const questionEditFirstCategory = $( '#q_category_1 option:selected' );
-                    if(questionEditFirstCategory.text() === 'Programowanie'){
-                        const questionEditSecondCategory = $( '#q_category_2 option:selected' );
-                	    const findCategory = categories.find( function(object) {
-                            return object.category == questionEditSecondCategory.text();
-                        });
+                            const questionEditFirstCategory = $( '#q_category_1 option:selected' );
+                            if(questionEditFirstCategory.text() === 'Programowanie'){
+                                const questionEditSecondCategory = $( '#q_category_2 option:selected' );
+                	        const findCategory = categories.find( function(object) {
+                                    return object.category == questionEditSecondCategory.text();
+                                });
 			
-        			    if(findCategory != undefined){
-				            CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-				        } else {
-				            CKEDITOR.config.syntaxhighlight_lang = 'plain';
-				        }
-                    }
-                });
+                        	if(findCategory != undefined){
+				    CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+				} else {
+				    CKEDITOR.config.syntaxhighlight_lang = 'plain';
+				}
+                            }    
+                        });
 				
 	        } else {
-                codeBlock.addEventListener( 'click', () => {
+                    codeBlock.addEventListener( 'click', () => {
 				
-                    const category = $( '.qa-q-view-where-data' );
-			        const findCategory = categories.find( function(object) {
-                        return object.category == category.text();
-                    });
+                        const category = $( '.qa-q-view-where-data' );
+			const findCategory = categories.find( function(object) {
+                            return object.category == category.text();
+                        });
 				
-				    if(findCategory != undefined){
-				        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
-				    } else {
-					    CKEDITOR.config.syntaxhighlight_lang = 'plain';
-				    }
+			if(findCategory != undefined){
+			    CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+			} else {
+			    CKEDITOR.config.syntaxhighlight_lang = 'plain';
+			}
 				
-                });
+                     });
             }		   
         });
     }

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -1,111 +1,72 @@
-if (typeof CKEDITOR != 'undefined') {
-    CKEDITOR.on( "instanceReady", function() {
-        const codeBlock = document.getElementById( "cke_43" );
-        if ( location.href.includes( "/ask" ) ) {
-            codeBlock.addEventListener( "click", function() {
-                const category_1 = $('#category_1 option:selected');
-                if(category_1.text() === 'Programowanie') {
-                    const category_2 = $('#category_2 option:selected');			
-                    switch(category_2.text()){
-                        case 'HTML i CSS':
-                            CKEDITOR.config.syntaxhighlight_lang = 'xml';
-                        break;
-                        case 'C i C++':
-                            CKEDITOR.config.syntaxhighlight_lang = 'cpp';
-                        break;
-                        case 'JavaScript, jQuery, AJAX':
-                            CKEDITOR.config.syntaxhighlight_lang = 'jscript';
-                        break;
-                        case 'PHP, Symfony, Zend':
-                            CKEDITOR.config.syntaxhighlight_lang = 'php';
-                        break;
-                        case 'SQL, bazy danych':
-                            CKEDITOR.config.syntaxhighlight_lang = 'sql';
-                        break;
-                        case 'C# i .NET':
-                            CKEDITOR.config.syntaxhighlight_lang = 'csharp';
-                        break;
-                        case 'Java':
-                            CKEDITOR.config.syntaxhighlight_lang = 'java';
-                        break;
-                        case 'Python, Django':
-                            CKEDITOR.config.syntaxhighlight_lang = 'python';
-                        break;
-                        default:
-                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
-                        break;
-                    }    			
-                }    
-            });
-        } else if ( location.href.includes( "edit" ) ) {
-                codeBlock.addEventListener( "click", function() {
-                const questionEditCategory_1 = $('#q_category_1 option:selected');
-                if(questionEditCategory_1.text() === 'Programowanie'){
-                    const questionEditCategory_2 = $('#q_category_2 option:selected');
-                    switch(questionEditCategory_2.text()){
-                        case 'HTML i CSS':
-                            CKEDITOR.config.syntaxhighlight_lang = 'xml';
-                        break;
-                        case 'C i C++':
-                            CKEDITOR.config.syntaxhighlight_lang = 'cpp';
-                        break;
-                        case 'JavaScript, jQuery, AJAX':
-                            CKEDITOR.config.syntaxhighlight_lang = 'jscript';
-                        break;
-                        case 'PHP, Symfony, Zend':
-                            CKEDITOR.config.syntaxhighlight_lang = 'php';
-                        break;
-                        case 'SQL, bazy danych':
-                            CKEDITOR.config.syntaxhighlight_lang = 'sql';
-                        break;
-                        case 'C# i .NET':
-                            CKEDITOR.config.syntaxhighlight_lang = 'csharp';
-                        break;
-                        case 'Java':
-                            CKEDITOR.config.syntaxhighlight_lang = 'java';
-                        break;
-                        case 'Python, Django':
-                            CKEDITOR.config.syntaxhighlight_lang = 'python';
-                        break;
-                        default:
-                            CKEDITOR.config.syntaxhighlight_lang = 'plain';
-                        break;
-                    }   		
-                }
-            });
-	    } else {
-            codeBlock.addEventListener( 'click', function() {
-                const category = $('.qa-q-view-where-data').text();
-                switch(category){
-                    case 'HTML i CSS':
-                        CKEDITOR.config.syntaxhighlight_lang = 'xml';
-                    break;
-                    case 'C i C++':
-                        CKEDITOR.config.syntaxhighlight_lang = 'cpp';
-                    break;
-                    case 'JavaScript, jQuery, AJAX':
-                        CKEDITOR.config.syntaxhighlight_lang = 'jscript';
-                    break;
-                    case 'PHP, Symfony, Zend':
-                        CKEDITOR.config.syntaxhighlight_lang = 'php';
-                    break;
-                    case 'SQL, bazy danych':
-                        CKEDITOR.config.syntaxhighlight_lang = 'sql';
-                    break;
-                    case 'C# i .NET':
-                        CKEDITOR.config.syntaxhighlight_lang = 'csharp';
-                    break;
-                    case 'Java':
-                        CKEDITOR.config.syntaxhighlight_lang = 'java';
-                    break;
-                    case 'Python, Django':
-                        CKEDITOR.config.syntaxhighlight_lang = 'python';
-                    break;
-                    default:
-                        CKEDITOR.config.syntaxhighlight_lang = 'plain';
-                    break;
-                }   
-            });
-        }		   
-    });
+document.addEventListener("DOMContentLoaded", function(event) {
+    if (typeof CKEDITOR != 'undefined') {
+        CKEDITOR.on( 'instanceReady', function() {
+            const categories = [
+                {category : 'HTML i CSS', language: 'xml'},
+                {category : 'C i C++', language: 'cpp'},
+                {category : 'JavaScript, jQuery, AJAX', language: 'jscript'},
+                {category : 'PHP, Symfony, Zend', language: 'php'},
+                {category : 'SQL, bazy danych', language: 'sql'},
+                {category : 'C# i .NET', language: 'csharp'},
+                {category : 'Java', language: 'java'},
+                {category : 'Python, Django', language: 'python'},
+            ]
+            const codeBlock = document.getElementById( 'cke_43' );
+		
+            if ( location.href.includes( '/ask' ) ) {
+                codeBlock.addEventListener( 'click', () => {
+                    const firstCategory = $( '#category_1 option:selected' );
+				
+                    if(firstCategory.text() === 'Programowanie') {
+                        const secondCategory = $( '#category_2 option:selected' );			
+					    const findCategory = categories.find( function(object) {
+                            return object.category == secondCategory.text();
+                        });
+					
+				        if(findCategory != undefined){
+					        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+				        } else {
+						    CKEDITOR.config.syntaxhighlight_lang = 'plain';
+					    }
+			
+                    }
+				
+			    });
+			
+		    } else if ( location.href.includes( 'edit' ) ) {
+                codeBlock.addEventListener( 'click', () => {
+					
+                    const questionEditFirstCategory = $( '#q_category_1 option:selected' );
+                    if(questionEditFirstCategory.text() === 'Programowanie'){
+                        const questionEditSecondCategory = $( '#q_category_2 option:selected' );
+                	    const findCategory = categories.find( function(object) {
+                            return object.category == questionEditSecondCategory.text();
+                        });
+			
+        			    if(findCategory != undefined){
+				            CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+				        } else {
+				            CKEDITOR.config.syntaxhighlight_lang = 'plain';
+				        }
+                    }
+                });
+				
+	        } else {
+                codeBlock.addEventListener( 'click', () => {
+				
+                    const category = $( '.qa-q-view-where-data' );
+			        const findCategory = categories.find( function(object) {
+                        return object.category == category.text();
+                    });
+				
+				    if(findCategory != undefined){
+				        CKEDITOR.config.syntaxhighlight_lang = findCategory.language;
+				    } else {
+					    CKEDITOR.config.syntaxhighlight_lang = 'plain';
+				    }
+				
+                });
+            }		   
+        });
+    }
 }

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -12,9 +12,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 {category : 'Python, Django', language: 'python'},
             ]
             const codeBlock = document.getElementById( 'cke_43' );
-		
+            let clickHandler;
             if ( location.href.includes( '/ask' ) ) {
-                codeBlock.addEventListener( 'click', () => {
+                clickHandler = () => {
                     const firstCategory = document.querySelector( '#category_1' );
                     const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
                     if(selectedFirstOption.textContent === 'Programowanie') {
@@ -29,10 +29,10 @@ document.addEventListener("DOMContentLoaded", () => {
                             CKEDITOR.config.syntaxhighlight_lang = 'plain';		
                     }
                      		
-                });
+                };
 	         	
             } else if ( location.href.includes( 'edit' ) ) {
-                codeBlock.addEventListener( 'click', () => {
+                clickHandler = () => {
 	               			
                     const firstCategory = document.querySelector( '#q_category_1' );
                     const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
@@ -46,10 +46,10 @@ document.addEventListener("DOMContentLoaded", () => {
                     } else {		
                             CKEDITOR.config.syntaxhighlight_lang = 'plain';			
                     }
-                });
+                };
 	        		
 	    } else {
-                codeBlock.addEventListener( 'click', () => {
+                clickHandler = () => {
 				
                     const category = document.querySelector( '.qa-q-view-where-data' );
                     const findCategory = categories.find( function(object) {
@@ -58,8 +58,9 @@ document.addEventListener("DOMContentLoaded", () => {
 		     	
                    CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
 				
-                });
-            }		   
+                };
+            }
+        codeBlock.addEventListener( 'click', clickHandler );	
         });
     }
 });

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -19,13 +19,13 @@ document.addEventListener("DOMContentLoaded", () => {
                     const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
                     if(selectedFirstOption.textContent === 'Programowanie') {
                         const secondCategory = document.querySelector( '#category_2' );
-                        const selectedSecondOption = firstCategory.children[ secondCategory.selectedIndex ];			
+                        const selectedSecondOption = secondCategory.children[ secondCategory.selectedIndex ];			
                         const findCategory = categories.find( function(object) {
                             return object.category == selectedSecondOption.textContent;
                         });
 	                 
                             CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
-		    } else {		
+		            } else {		
                             CKEDITOR.config.syntaxhighlight_lang = 'plain';		
                     }
                      		
@@ -38,8 +38,9 @@ document.addEventListener("DOMContentLoaded", () => {
                     const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
                     if(selectedFirstOption.textContent === 'Programowanie') {
                         const secondCategory = document.querySelector( '#q_category_2' );
+                        const selectedSecondOption = secondCategory.children[ secondCategory.selectedIndex ];
                         const findCategory = categories.find( function(object) {
-                            return object.category == secondCategory.textContent;
+                            return object.category == selectedSecondOption.textContent;
                         });
 		            
                             CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';

--- a/forum/qa-theme/SnowFlat/qa-theme.php
+++ b/forum/qa-theme/SnowFlat/qa-theme.php
@@ -146,6 +146,7 @@ class qa_html_theme extends qa_html_theme_base
     {
         $jsUrl = $this->rooturl . $this->js_dir . 'snow-core.js?' . QA_VERSION;
         $this->content['script'][] = '<script src="' . $jsUrl . '"></script>';
+        $this->content['script'][] = '<script src="' . $this->rooturl . $this->js_dir .'selectLanguage.js' . '"></script>';
 
         qa_html_theme_base::head_script();
     }


### PR DESCRIPTION
Od teraz, podczas zadawania pytania

- bloczek z kodem będzie sprawdzał wybraną kategorię (jeżeli takiej nie zaznaczono to będzie standardowy Plain Text)

I podczas udzielania odpowiedzi 

- bloczek z kodem będzie sprawdzał kategorię pytania, i na jej podstawie wybierał preferowany język

Czyli jeżeli ktoś zada pytanie w kategorii PHP, Symfony, Zend bloczek z kodem automatycznie zasugeruje PHP jako język kolorowania składni. Analogicznie do innych kategorii (nie wszystkich) i odpowiedzi na pytanie. 