### PR TITLE
Aktualizacja URLa dla obrazka Codepen przy snippecie

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -242,10 +242,9 @@ function qa_ajax_error()
 			dataCarrierInput.name = 'data';
 			dataCarrierInput.value = codeAsJSON;
 
-			var submitSnippet = document.createElement('input');
-			submitSnippet.type = 'image';
-			submitSnippet.src = 'https://blog.codepen.io/wp-content/uploads/2012/06/codepen-wordmark-display-inside-white@10x.png';
-			submitSnippet.value = 'Create new CODEPEN';
+            var submitSnippet = document.createElement('input');
+            submitSnippet.type = 'submit';
+            submitSnippet.value = 'CODEPEN';
 
 			codepenSnippetForm.appendChild(dataCarrierInput);
 			codepenSnippetForm.appendChild(submitSnippet);

--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -244,7 +244,7 @@ function qa_ajax_error()
 
 			var submitSnippet = document.createElement('input');
 			submitSnippet.type = 'image';
-			submitSnippet.src = 'https://assets.codepen.io/assets/logos/codepen-logo-9c0933e8569e634b75ac2eb808da908d.svg';
+			submitSnippet.src = 'https://blog.codepen.io/wp-content/uploads/2012/06/codepen-wordmark-display-inside-white@10x.png';
 			submitSnippet.value = 'Create new CODEPEN';
 
 			codepenSnippetForm.appendChild(dataCarrierInput);

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4798,19 +4798,10 @@ form div.qa-q-view-content
     cursor: pointer;
 }
 
-.codepen-snippet img,
-.codepen-snippet input[type="image"]
+.codepen-snippet input[type="submit"]
 {
-    background: black;
-    border-radius: 10px;
-    margin: 0;
-    padding: 9px;
-    vertical-align: middle;
-    transform: scale(0.40);
-    width: 140px;
-    position: absolute;
-    right: 5px;
-    top: -11px;
+	background: black;
+	right: 47px;
 }
 
 .jsfiddle-snippet
@@ -4824,16 +4815,8 @@ form div.qa-q-view-content
 
 .jsfiddle-snippet input[type="submit"]
 {
-	border-radius: 6px;
     background: #4679A4;
-    color: white;
-    margin: 0;
-    position: absolute;
     right: 0;
-    top: 1px;
-    font-size: 8px;
-    padding: 4px;
-	height: 19px;
 }
 
 .jsfiddle-snippet select,
@@ -4845,6 +4828,18 @@ form div.qa-q-view-content
 .snippets-parent.inside-comment
 {
 	top: -10px;
+}
+
+.codepen-snippet input[type="submit"],
+.jsfiddle-snippet input[type="submit"] {
+	border-radius: 6px;
+    color: white;
+    margin: 0;
+    position: absolute;
+    top: 1px;
+    font-size: 8px;
+    padding: 4px;
+	height: 19px;
 }
 
 .entry-content.below-snippets

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4804,7 +4804,7 @@ form div.qa-q-view-content
     background: black;
     border-radius: 10px;
     margin: 0;
-    padding: 10px;
+    padding: 9px;
     vertical-align: middle;
     transform: scale(0.40);
     width: 140px;
@@ -4833,6 +4833,7 @@ form div.qa-q-view-content
     top: 1px;
     font-size: 8px;
     padding: 4px;
+	height: 19px;
 }
 
 .jsfiddle-snippet select,


### PR DESCRIPTION
@awaluk zgłosił mi, że obrazek dla przycisku Codepen się nie wyświetla. Podmieniłem więc linka i troszkę style zaktualizowałem (na Firefox przycisk dla JSFiddle miał zbyt dużą wysokość w stosunku do Chrome).