### PR TITLE
Zasugerowanie umieszczenia kodu w bloczkach z podlinkowaniem FAQ

### DIFF
--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -403,7 +403,7 @@ function set_category_description(idprefix)
                         Chyba zapomniałeś zamieścić kod źródłowy w przeznaczonym do tego bloczku.
                         <br>
                         Zobacz jak to zrobić
-                        <a target="_blank" href="https://forum.pasja-informatyki.pl/faq#jak-wstawic-kod-zrodlowy">tutaj</a>.
+                        <a target="_blank" href="https://forum.pasja-informatyki.pl/faq#jak-wstawic-kod-zrodlowy" title="Jak wstawić kod źródłowy?">tutaj</a>.
                     `;
                     askQuestionBtn.parentNode.insertBefore( warningDomElement, askQuestionBtn.parentNode.firstElementChild );
                 };

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -385,3 +385,54 @@ function set_category_description(idprefix)
 		});
 	});
 }(document));
+
+
+/*
+ * Suggest inserting code in appropriate blocks, when question category is "Programowanie"
+ */
+;( function() {
+    'use strict';
+
+    window.addEventListener( 'DOMContentLoaded', () => {
+        if ( location.href.includes( '/ask' ) ) {
+            CKEDITOR.on( 'instanceReady', () => {
+                const showIncorrectCodePlacementWarning = () => {
+                    const warningDomElement = document.createElement( 'div' );
+                    warningDomElement.classList.add( 'incorrect-code-placement-warning' );
+                    warningDomElement.innerHTML = `
+                        Chyba zapomniałeś zamieścić kod źródłowy w przeznaczonym do tego bloczku.
+                        <br>
+                        Zobacz jak to zrobić
+                        <a target="_blank" href="https://forum.pasja-informatyki.pl/faq#jak-wstawic-kod-zrodlowy">tutaj</a>.
+                    `;
+                    askQuestionBtn.parentNode.insertBefore( warningDomElement, askQuestionBtn.parentNode.firstElementChild );
+                };
+                const questionEditorDocument = CKEDITOR.instances.content.document.$;
+                const askQuestionBtn = document.getElementById( '__form-send' );
+                const categorySelect = document.getElementById( 'category_1' );
+
+                // Use capture phase on <body> to block submitting before any [onclick] on button will be triggered.
+                document.body.addEventListener( 'click', ( event ) => {
+                    if ( event.srcElement && event.srcElement.id === askQuestionBtn.id ) {
+                        const selectedCategory = categorySelect.options[ categorySelect.selectedIndex ].textContent;
+
+                        if ( selectedCategory === 'Programowanie' ) {
+                            const isCodeBlockInEditor = !!( questionEditorDocument.querySelector( '[class^="brush"]' ) );
+
+                            if ( !isCodeBlockInEditor ) {
+                                event.preventDefault();
+                                event.stopPropagation();
+
+                                showIncorrectCodePlacementWarning();
+                            }
+                        }
+                    }
+                }, {
+                    capture: true,
+                    once: true
+                } );
+            } );
+        }
+    } );
+
+} () );

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -412,7 +412,7 @@ function set_category_description(idprefix)
                 const categorySelect = document.getElementById( 'category_1' );
 
                 // Use capture phase on <body> to block submitting before any [onclick] on button will be triggered.
-                document.body.addEventListener( 'click', ( event ) => {
+                document.body.addEventListener( 'click', function preventSubmit( event ) {
                     if ( event.srcElement && event.srcElement.id === askQuestionBtn.id ) {
                         const selectedCategory = categorySelect.options[ categorySelect.selectedIndex ].textContent;
 
@@ -424,13 +424,11 @@ function set_category_description(idprefix)
                                 event.stopPropagation();
 
                                 showIncorrectCodePlacementWarning();
+                                document.body.removeEventListener( 'click', preventSubmit, true );
                             }
                         }
                     }
-                }, {
-                    capture: true,
-                    once: true
-                } );
+                }, true );
             } );
         }
     } );

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -400,9 +400,9 @@ function set_category_description(idprefix)
                     const warningDomElement = document.createElement( 'div' );
                     warningDomElement.classList.add( 'incorrect-code-placement-warning' );
                     warningDomElement.innerHTML = `
-                        Chyba zapomniałeś zamieścić kod źródłowy w przeznaczonym do tego bloczku.
-                        <br>
-                        Zobacz jak to zrobić
+						Czy to pytanie nie powinno zawierać kodu? Jeśli tak, upewnij się, że wstawiłeś go w przeznaczony do tego bloczek.
+					 	<br>
+					 	Instrukcję znajdziesz 
                         <a target="_blank" href="https://forum.pasja-informatyki.pl/faq#jak-wstawic-kod-zrodlowy" title="Jak wstawić kod źródłowy?">tutaj</a>.
                     `;
                     askQuestionBtn.parentNode.insertBefore( warningDomElement, askQuestionBtn.parentNode.firstElementChild );
@@ -410,21 +410,32 @@ function set_category_description(idprefix)
                 const questionEditorDocument = CKEDITOR.instances.content.document.$;
                 const askQuestionBtn = document.getElementById( '__form-send' );
                 const categorySelect = document.getElementById( 'category_1' );
+                const excludedSubCategories = [ 'Hostingi, domeny', 'Systemy CMS', 'Algorytmy' ];
+                const isChosenSubCategoryExcluded = ( chosenSubCategory ) => {
+					return excludedSubCategories.some( ( subCategory ) => {
+						return chosenSubCategory === subCategory;
+					} );
+				};
 
                 // Use capture phase on <body> to block submitting before any [onclick] on button will be triggered.
                 document.body.addEventListener( 'click', function preventSubmit( event ) {
                     if ( event.srcElement && event.srcElement.id === askQuestionBtn.id ) {
-                        const selectedCategory = categorySelect.options[ categorySelect.selectedIndex ].textContent;
+                        const subCategorySelect = document.getElementById( 'category_2' );
 
-                        if ( selectedCategory === 'Programowanie' ) {
-                            const isCodeBlockInEditor = !!( questionEditorDocument.querySelector( '[class^="brush"]' ) );
+                        if ( subCategorySelect ) {
+                            const selectedCategory = categorySelect.options[ categorySelect.selectedIndex ].textContent;
+                            const selectedSubCategory = subCategorySelect.options[ subCategorySelect.selectedIndex ].textContent;
 
-                            if ( !isCodeBlockInEditor ) {
-                                event.preventDefault();
-                                event.stopPropagation();
+                            if ( selectedCategory === 'Programowanie' && !isChosenSubCategoryExcluded( selectedSubCategory ) ) {
+                                const isCodeBlockInEditor = !!( questionEditorDocument.querySelector( '[class^="brush"]' ) );
 
-                                showIncorrectCodePlacementWarning();
-                                document.body.removeEventListener( 'click', preventSubmit, true );
+                                if ( !isCodeBlockInEditor ) {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+
+                                    showIncorrectCodePlacementWarning();
+                                    document.body.removeEventListener( 'click', preventSubmit, true );
+                                }
                             }
                         }
                     }

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4871,3 +4871,39 @@ form div.qa-q-view-content
 	color: #3498db;
 	text-decoration: underline;
 }
+
+@keyframes warningBlink {
+    0%, 100% {
+        background: white;
+        color: orange;
+    }
+
+    50% {
+        background: orange;
+        color: white;
+    }
+}
+
+@keyframes warningAnchorBlink {
+    0%, 100% {
+        color: #2980b9;
+    }
+
+    50% {
+        color: white;
+    }
+}
+
+.incorrect-code-placement-warning {
+    border: 2px solid orange;
+    color: orange;
+    padding: 5px;
+    text-align: center;
+    font-weight: bold;
+    margin-bottom: 5px;
+    animation: warningBlink 1.5s ease-in-out;
+}
+
+.incorrect-code-placement-warning a {
+    animation: warningAnchorBlink 1.5s ease-in-out;
+}


### PR DESCRIPTION
Często zdarza się, że użytkownicy nie podają kodu źródłowego podczas zadawania pytania. Ten ficzer sprawdza, czy wybrana kategoria pytania to "Programowanie", a następnie weryfikuje, czy w treści pytania ~~zawarty jest kod i czy jest on umieszczony w bloczku.~~ umieszczony jest bloczek z kodem.

Sugestia pojawia się jako mignięcie (aby zwrócić uwagę) i początkowo blokuje zatwierdzenie pytania. Jednak, aby nie być w tej sytuacji natarczywym (bo pytanie we wspomnianej kategorii może nie wymagać zamieszczania kodu) ponowne kliknięcie w "Zadaj pytanie" zatwierdza je.

Liczę na feedback w kwestii ostylowania komunikatu - czy taka kolorystyka i efekt mrugnięcia będą Waszym zdaniem ok?

Myślę, że razem z [ficzerem](https://github.com/CodersCommunity/forum.pasja-informatyki.local/pull/125) autorstwa @Mariusz08, będzie to pomocne usprawnienie dla odpowiedniego zamieszczania kodu.