### PR TITLE
Naprawa stron 403 Forbidden

### DIFF
--- a/dump/forum.sql
+++ b/dump/forum.sql
@@ -699,7 +699,7 @@ INSERT INTO `qa_options` (`title`, `content`) VALUES
 ('captcha_on_reset_password', '1'),
 ('captcha_on_unapproved', '0'),
 ('captcha_on_unconfirmed', '0'),
-('ckeditor4_config', 'toolbarCanCollapse:false,\nremovePlugins:''elementspath'',\nresize_enabled:true,\nautogrow:true,\nentities:false,\nextraPlugins:''syntaxhighlight'',\ndisableNativeSpellChecker:false,\npasteFromWordRemoveFontStyles:true,\npasteFromWordRemoveStyles:true,\nforcePasteAsPlainText:true'),
+('ckeditor4_config', 'toolbarCanCollapse:false,\nremovePlugins:''elementspath,contextmenu,tabletools,liststyle'',\nresize_enabled:true,\nautogrow:false,\nentities:false,extraPlugins:''syntaxhighlight'',\ndisableNativeSpellChecker:false,\npasteFromWordRemoveFontStyles:true,\npasteFromWordRemoveStyles:true'),
 ('ckeditor4_config_advanced', 'toolbarCanCollapse:false,\nremovePlugins:''elementspath'',\nresize_enabled:false,\nautogrow:false,\nentities:false'),
 ('ckeditor4_htmLawed_anti_link_spam', '/.*/,'),
 ('ckeditor4_htmLawed_controler', '0'),

--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -242,10 +242,9 @@ function qa_ajax_error()
 			dataCarrierInput.name = 'data';
 			dataCarrierInput.value = codeAsJSON;
 
-			var submitSnippet = document.createElement('input');
-			submitSnippet.type = 'image';
-			submitSnippet.src = 'https://assets.codepen.io/assets/logos/codepen-logo-9c0933e8569e634b75ac2eb808da908d.svg';
-			submitSnippet.value = 'Create new CODEPEN';
+            var submitSnippet = document.createElement('input');
+            submitSnippet.type = 'submit';
+            submitSnippet.value = 'CODEPEN';
 
 			codepenSnippetForm.appendChild(dataCarrierInput);
 			codepenSnippetForm.appendChild(submitSnippet);

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -1,0 +1,72 @@
+document.addEventListener("DOMContentLoaded", () => {
+    if (typeof CKEDITOR != 'undefined') {
+        CKEDITOR.on( 'instanceReady', function() {
+            const categories = [
+                {category : 'HTML i CSS', language: 'xml'},
+                {category : 'C i C++', language: 'cpp'},
+                {category : 'JavaScript, jQuery, AJAX', language: 'jscript'},
+                {category : 'PHP, Symfony, Zend', language: 'php'},
+                {category : 'SQL, bazy danych', language: 'sql'},
+                {category : 'C# i .NET', language: 'csharp'},
+                {category : 'Java', language: 'java'},
+                {category : 'Python, Django', language: 'python'},
+            ]
+            const codeBlock = document.getElementById( 'cke_43' );
+            let clickHandler;
+            if ( location.href.includes( '/ask' ) ) {
+                clickHandler = () => {
+                    const firstCategory = document.querySelector( '#category_1' );
+                    const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
+                    if(selectedFirstOption.textContent === 'Programowanie') {
+                        const secondCategory = document.querySelector( '#category_2' );
+                        const selectedSecondOption = secondCategory.children[ secondCategory.selectedIndex ];			
+                        const findCategory = categories.find( function(object) {
+                            return object.category == selectedSecondOption.textContent;
+                        });
+	                 
+                            CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
+		    } else {		
+                            CKEDITOR.config.syntaxhighlight_lang = 'plain';		
+                    }
+                     		
+                };
+	         	
+           } else if ( location.href.includes( 'edit' ) ) {
+                clickHandler = () => {
+	               			
+                    let findCategory;	
+                    const firstCategory = document.querySelector( '#q_category_1' );
+                    if(firstCategory) {
+                        const selectedFirstOption = firstCategory.children[ firstCategory.selectedIndex ];                       	
+						if(selectedFirstOption.textContent === 'Programowanie') {
+                            const secondCategory = document.querySelector( '#q_category_2' );
+                            const selectedSecondOption = secondCategory.children[ secondCategory.selectedIndex ];
+                            findCategory = categories.find( ( object ) => {
+                                return object.category == selectedSecondOption.textContent;
+                            });
+                        }
+                    } else {
+                       const category = document.querySelector( '.qa-q-view-where-data' );
+                       findCategory = categories.find( ( object ) => {
+                            return object.category == category.textContent;
+                        });
+                    }
+                    CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
+                };
+	        		
+	    } else {
+                clickHandler = () => {
+				
+                    const category = document.querySelector( '.qa-q-view-where-data' );
+                    const findCategory = categories.find( function(object) {
+                        return object.category == category.textContent;
+                    });
+		     	
+                   CKEDITOR.config.syntaxhighlight_lang = findCategory ? findCategory.language : 'plain';
+				
+                };
+            }
+        codeBlock.addEventListener( 'click', clickHandler );	
+        });
+    }
+});

--- a/forum/qa-theme/SnowFlat/js/selectLanguage.js
+++ b/forum/qa-theme/SnowFlat/js/selectLanguage.js
@@ -11,7 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 {category : 'Java', language: 'java'},
                 {category : 'Python, Django', language: 'python'},
             ]
-            const codeBlock = document.getElementById( 'cke_43' );
+            const codeBlock = document.getElementById( 'cke_42' );
             let clickHandler;
             if ( location.href.includes( '/ask' ) ) {
                 clickHandler = () => {

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4798,19 +4798,10 @@ form div.qa-q-view-content
     cursor: pointer;
 }
 
-.codepen-snippet img,
-.codepen-snippet input[type="image"]
+.codepen-snippet input[type="submit"]
 {
-    background: black;
-    border-radius: 10px;
-    margin: 0;
-    padding: 10px;
-    vertical-align: middle;
-    transform: scale(0.40);
-    width: 140px;
-    position: absolute;
-    right: 5px;
-    top: -11px;
+	background: black;
+	right: 47px;
 }
 
 .jsfiddle-snippet
@@ -4824,15 +4815,8 @@ form div.qa-q-view-content
 
 .jsfiddle-snippet input[type="submit"]
 {
-	border-radius: 6px;
     background: #4679A4;
-    color: white;
-    margin: 0;
-    position: absolute;
     right: 0;
-    top: 1px;
-    font-size: 8px;
-    padding: 4px;
 }
 
 .jsfiddle-snippet select,
@@ -4844,6 +4828,18 @@ form div.qa-q-view-content
 .snippets-parent.inside-comment
 {
 	top: -10px;
+}
+
+.codepen-snippet input[type="submit"],
+.jsfiddle-snippet input[type="submit"] {
+	border-radius: 6px;
+    color: white;
+    margin: 0;
+    position: absolute;
+    top: 1px;
+    font-size: 8px;
+    padding: 4px;
+	height: 19px;
 }
 
 .entry-content.below-snippets

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4871,3 +4871,39 @@ form div.qa-q-view-content
 	color: #3498db;
 	text-decoration: underline;
 }
+
+@keyframes warningBlink {
+    0%, 100% {
+        background: white;
+        color: orange;
+    }
+
+    50% {
+        background: orange;
+        color: white;
+    }
+}
+
+@keyframes warningAnchorBlink {
+    0%, 100% {
+        color: #2980b9;
+    }
+
+    50% {
+        color: white;
+    }
+}
+
+.incorrect-code-placement-warning {
+    border: 2px solid orange;
+    color: orange;
+    padding: 5px;
+    text-align: center;
+    font-weight: bold;
+    margin-bottom: 5px;
+    animation: warningBlink 1.5s ease-in-out;
+}
+
+.incorrect-code-placement-warning a {
+    animation: warningAnchorBlink 1.5s ease-in-out;
+}

--- a/forum/qa-theme/SnowFlat/qa-theme.php
+++ b/forum/qa-theme/SnowFlat/qa-theme.php
@@ -146,6 +146,7 @@ class qa_html_theme extends qa_html_theme_base
     {
         $jsUrl = $this->rooturl . $this->js_dir . 'snow-core.js?' . QA_VERSION;
         $this->content['script'][] = '<script src="' . $jsUrl . '"></script>';
+        $this->content['script'][] = '<script src="' . $this->rooturl . $this->js_dir .'selectLanguage.js' . '"></script>';
 
         qa_html_theme_base::head_script();
     }


### PR DESCRIPTION
Mała poprawka związana z niepoprawnym wyświetlaniem się strony po wejściu w katalog. Przykładowo https://forum.pasja-informatyki.pl/qa-include/ wyświetla "popsutą" stronę główną, zamiast jakiegoś błędu typu "404 Strona nie istnieje" lub "403 Dostęp do strony zakazany".
Zdaję sobie sprawę, że to rozwiązanie nie jest najlepsze (mam tutaj na myśli wpisywanie na sztywno ścieżki do webroota), ale chyba lepsze takie, niż żadne. Nie spieszyłem się z PR, bo myślałem, że może uda się poszukać jakiegoś lepszego sposobu, ale do teraz się za to nie zabrałem, więc robię tego PRa aby nie zapomnieć o tym.
Przetestowałem u siebie i działa jak należy. Prosiłbym również o testy z Waszej strony.
Gdyby ktoś miał jakieś lepsze rozwiązanie pozwalające na ominięcie podawania bezwzględnej ścieżki (którą na produkcji by trzeba zmienić - jak mówiłem, takie średnie rozwiązanie), która jest zależna od środowiska, to bardzo proszę o odpowiedź.