### PR TITLE
Add const and let to brush

### DIFF
--- a/forum/qa-content/javascript/shBrushJScript.js
+++ b/forum/qa-content/javascript/shBrushJScript.js
@@ -25,7 +25,8 @@
 						'default delete do else false  ' +
 						'for function if in instanceof ' +
 						'new null return super switch ' +
-						'this throw true try typeof var while with'
+						'this throw true try typeof var while with' +
+		                                'let const'
 						;
 
 		var r = SyntaxHighlighter.regexLib;


### PR DESCRIPTION
Bloczek z kodem ustawiony na JavaScript nie koloruje `let` ani `const`, co jest dużym przeoczeniem, gdyż ta składnia jest już standardem. Przygotowałem fix który dodaje do kolorowania te dwa napisy.