### PR TITLE
[Feature] [Plugin] Automatyczne wysyłanie wiadomości PW do nowo zarejestrowanego użytkownika

### DIFF
--- a/forum/qa-plugin/send-pw-on-register/metadata.json
+++ b/forum/qa-plugin/send-pw-on-register/metadata.json
@@ -1,0 +1,13 @@
+{
+    "name": "Auto-send register PW message.",
+    "uri": "https://github.com/CodersCommunity/forum.pasja-informatyki.local",
+    "description": "This plugin automatically send private message to new user.",
+    "version": "1.0",
+    "date": "2018-06-10",
+    "author": "Mariusz08",
+    "author_uri": "https://forum.pasja-informatyki.pl/user/Mariusz08",
+    "license": "GNU GPL v2",
+    "update_uri": "https://github.com/CodersCommunity/forum.pasja-informatyki.local",
+    "min_q2a": "1.7",
+    "min_php": "5.3"
+}

--- a/forum/qa-plugin/send-pw-on-register/qa-plugin.php
+++ b/forum/qa-plugin/send-pw-on-register/qa-plugin.php
@@ -1,0 +1,34 @@
+<?php
+/*
+    Plugin Name: Auto-send register PW message.
+    Plugin URI: https://github.com/CodersCommunity/forum.pasja-informatyki.local
+    Plugin Description: This plugin automatically send private message to new user.
+    Plugin Version: 1.0
+    Plugin Date: 2018-06-10 
+    Plugin Author: Mariusz08
+    Plugin Author URI: https://forum.pasja-informatyki.pl/user/Mariusz08
+    Plugin License: GNU GPL v2
+    Plugin Update Check URI: https://github.com/CodersCommunity/forum.pasja-informatyki.local
+    Plugin Minimum Question2Answer Version: 1.7
+    Plugin Minimum PHP Version: 5.3
+*/
+
+if (!defined('QA_VERSION')) {
+    header('Location: ../../');
+    exit;
+}
+
+qa_register_plugin_module(
+  'event',
+  'qa-pw-admin.php',
+  'qa_pw_admin',
+  'PW Admin'
+);
+
+qa_register_plugin_module(
+  'event',
+  'qa-pw-event.php',
+  'qa_pw_event',
+  'PW Event');
+
+?>

--- a/forum/qa-plugin/send-pw-on-register/qa-pw-admin.php
+++ b/forum/qa-plugin/send-pw-on-register/qa-pw-admin.php
@@ -1,0 +1,52 @@
+<?php
+
+class qa_pw_admin
+{
+    public function admin_form(&$qa_content)
+    {
+        $isSaved = false;
+
+        if (qa_clicked('sendPwMessageOnRegister_save')) {
+            qa_opt('sendPwMessageOnRegister_messageContent', qa_post_text('messageContent'));
+            qa_opt('sendPwMessageOnRegister_enabled', qa_post_text('enablePlugin'));
+            qa_opt('sendPwMessageOnRegister_botId', qa_post_text('botId'));
+            
+            $isSaved = true;
+        }
+        
+        return $this->prepareAdminForm($isSaved);
+    }
+    
+    private function prepareAdminForm($isSaved)
+    {
+        return [
+            'ok' => $isSaved ? 'Settings saved' : null,
+            'fields' => [
+                [
+                    'label' => 'Enable plugin',
+                    'tags' => 'name="enablePlugin"',
+                    'value' => qa_opt('sendPwMessageOnRegister_enabled'),
+                    'type' => 'checkbox'
+                ],
+                [
+                    'label' => '<span style="color: red; font-weight: bold;">DANGER ZONE!</span> Bot for sending messages (id): <span style="color: red; font-weight: bold;">DANGER ZONE!</span>',
+                    'tags' => 'name="botId" type="number"',
+                    'value' => qa_opt('sendPwMessageOnRegister_botId')
+                ],
+                [
+                    'label' => 'Message content:',
+                    'tags' => 'name="messageContent"',
+                    'value' => qa_html(qa_opt('sendPwMessageOnRegister_messageContent')),
+                    'type' => 'textarea',
+                    'rows' => 20
+                ]
+            ],
+            'buttons' => [
+                [
+                    'label' => 'Save Changes',
+                    'tags' => 'name="sendPwMessageOnRegister_save"',
+                ]
+            ]
+        ];        
+    }
+}

--- a/forum/qa-plugin/send-pw-on-register/qa-pw-event.php
+++ b/forum/qa-plugin/send-pw-on-register/qa-pw-event.php
@@ -1,0 +1,28 @@
+<?php
+
+class qa_pw_event
+{
+    public function process_event($event, $userId, $handle, $cookieId, $params)
+    {
+        if (qa_opt('sendPwMessageOnRegister_enabled') && 'u_register' === $event) {
+                require_once QA_INCLUDE_DIR.'db/messages.php';
+                $messsageId = qa_db_message_create(
+                    qa_opt('sendPwMessageOnRegister_botId'),
+                     $userId,
+                    qa_opt('sendPwMessageOnRegister_messageContent'),
+                    ''
+                );
+                $paramString = 'userid=' . $userId . ' handle=' . $handle . ' messageid=' . $messageId . ' message=' . qa_opt('sendPwMessageOnRegister_messageContent');
+                qa_db_query_sub(
+                    'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) '.
+                    'VALUES (NOW(), $, $, $, #, $, $)',
+                    qa_remote_ip_address(),
+                    qa_opt('sendPwMessageOnRegister_botId'),
+                    $handle,
+                    $cookieId,
+                    'u_message',
+                    $paramString
+                );
+        }
+    }
+}


### PR DESCRIPTION
Tak jak w tytule; plugin ma za zadanie umożliwić userowi zapoznać się z systemem wiadomości prywatnych. Sama wiadomość jest ustalana w panelu administratora a także ID bota (usera od którego będzie szła wiadomość)

Ps. Wie ktoś może jak wysłać powiadomienie do usera? Trzeba chyba dodać jakiś wpis w  qa_eventlog ale dodałem ich ok. 70 a żaden nie działa. Jakieś pomysły? ;)