### PR TITLE
Fix displaying code blocks in posts

### DIFF
--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4574,7 +4574,14 @@ a.sidebarnav:hover {
     line-height: 20px;
 }
 /* collapsing block-code */
-pre[class*="brush:"],
+pre[class*="brush:"]
+{
+	color: #252525;
+	position: relative;
+	height: 110px;
+	overflow: scroll;
+}
+
 .syntaxhighlighter-parent,
 .syntaxhighlighter
 {

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4578,7 +4578,7 @@ pre[class*="brush:"]
 {
 	color: #252525;
 	position: relative;
-	height: 110px;
+	max-height: 110px;
 	overflow: scroll;
 }
 


### PR DESCRIPTION
Poprawka ta wprowadza w miarę sensowny wygląd bloczka kodu, podczas gdy składnia nie została jeszcze pokolorowana (podczas ładowania strony). Tekst jest teraz czytelny (kontrast), a bloczek zwinięty.
U mnie wszystko wyświetla się jak należy. Prosiłbym jednak o Waszą opinię. Z góry dzięki! :smiley: