### PR TITLE
Aktualizacja Ubuntu w Vagrancie

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,10 +32,11 @@ Vagrant.configure("2") do |config|
             "--memory", 2048,
             "--natdnshostresolver1", "on",
             "--cpus", 1,
+            "--uartmode1", "disconnected"
         ]
     end
 
-    config.vm.box = "ubuntu/trusty64"
+    config.vm.box = "ubuntu/xenial64"
     
     config.vm.network :private_network, ip: "192.168.112.112"
     config.ssh.forward_agent = true

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
-  sudo: true
+  become: true
   vars_files:
     - vars/all.yml
   roles:

--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Apache
-  sudo: yes
+  become: true
   apt: pkg=apache2 state=latest
 
 - name: Install Apache Modules
@@ -17,13 +17,13 @@
   register: apache_version
 
 - name: Change default apache2.4 site
-  sudo: yes
+  become: true
   template: src=vhost24.conf.tpl dest=/etc/apache2/sites-available/000-default.conf
   notify: restart apache
   when: apache_version.stdout.find('Apache/2.4.') != -1
 
 - name: Change default apache2.2 site
-  sudo: yes
+  become: true
   template: src=vhost22.conf.tpl dest=/etc/apache2/sites-available/default
   notify: restart apache
   when: apache_version.stdout.find('Apache/2.2.') != -1

--- a/ansible/roles/mysql/tasks/main.yml
+++ b/ansible/roles/mysql/tasks/main.yml
@@ -4,7 +4,7 @@
   register: current_hostname
 
 - name: mysql | Install MySQL Packages
-  sudo: yes
+  become: true
   apt: pkg={{ item }} state=latest
   with_items:
     - mysql-server

--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 - name: Add ppa Repository
-  sudo: yes
+  become: true
   apt_repository: repo=ppa:ondrej/{{ php.ppa }}
 
 - name: Update apt
-  sudo: yes
+  become: true
   apt: update_cache=yes
 
 - name: Install php5
-  sudo: yes
+  become: true
   apt: pkg=php5.6 state=latest
 
 - name: Install php5-fpm
-  sudo: yes
+  become: true
   apt: pkg=php5.6-fpm state=latest
 
 - name: Install PHP Packages
-  sudo: yes
+  become: true
   apt: pkg={{ item }} state=latest
   with_items: 
    - php5.6-cli

--- a/ansible/roles/php/tasks/php_ini_configure.yml
+++ b/ansible/roles/php/tasks/php_ini_configure.yml
@@ -3,29 +3,29 @@
 
 - name: Display Errors in /etc/php/5.6/apache2/php.ini
   shell: sed -i -e 's/^display_errors =.*/display_errors = On/g' /etc/php/5.6/apache2/php.ini
-  sudo: yes
+  become: true
 
 - name: Display Errors in /etc/php/5.6/cli/php.ini
   shell: sed -i -e 's/^display_errors =.*/display_errors = On/g' /etc/php/5.6/cli/php.ini
-  sudo: yes
+  become: true
 
 - name: Display Errors in /etc/php/5.6/fpm/php.ini
   shell: sed -i -e 's/^display_errors =.*/display_errors = On/g' /etc/php/5.6/fpm/php.ini
-  sudo: yes
+  become: true
 
 # Error Reporting
 - name: Error Reporting in /etc/php/5.6/apache2/php.ini
   shell: sed -i -e 's/^error_reporting =.*/error_reporting = E_ALL/g' /etc/php/5.6/apache2/php.ini
-  sudo: yes
+  become: true
 
 - name: Error Reporting in //etc/php/5.6/cli/php.ini
   shell:  sed -i -e 's/^error_reporting =.*/error_reporting = E_ALL/g' /etc/php/5.6/cli/php.ini
-  sudo: yes
+  become: true
 
 - name: Display Errors in /etc/php/5.6/fpm/php.ini
   shell: sed -i -e 's/^error_reporting =.*/error_reporting = E_ALL/g' /etc/php/5.6/fpm/php.ini
-  sudo: yes
+  become: true
 
 - name: Reload all
   shell: service php5.6-fpm restart && service apache2 restart
-  sudo: yes
+  become: true

--- a/ansible/roles/server/tasks/main.yml
+++ b/ansible/roles/server/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Update apt
-  sudo: yes
+  become: true
   apt: update_cache=yes
 
 - name: Install System Packages
-  sudo: yes
+  become: true
   apt: pkg={{ item }} state=latest
   with_items:
     - curl
@@ -12,7 +12,7 @@
     - python-software-properties
 
 - name: Install Extra Packages
-  sudo: yes
+  become: true
   apt: pkg={{ item }} state=latest
   with_items:
     - htop
@@ -21,13 +21,13 @@
   when: server.packages is defined
 
 - name: Configure the timezone
-  sudo: yes
+  become: true
   template: src=timezone.tpl dest=/etc/timezone
 
 - name: More Configure the timezone
-  sudo: yes
+  become: true
   file: src=/usr/share/zoneinfo/{{server.timezone}} dest=/etc/localtime state=link force=yes backup=yes
 
 - name: Set default system language pack
   shell: locale-gen {{server.locale}}
-  sudo: yes
+  become: true

--- a/ansible/roles/xdebug/tasks/main.yml
+++ b/ansible/roles/xdebug/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Install xDebug
-  sudo: yes
+  become: true
   apt: pkg=php5.6-xdebug state=latest


### PR DESCRIPTION
Podczas przygotowywania maszyny pojawia się błąd o braku pakietu php5.6. Okazało się, że PPA do PHP z którego korzystamy ([ondrej/php](https://launchpad.net/~ondrej/+archive/ubuntu/php)) przestało wpierać Ubuntu Trusty z którego korzystał nasz Vagrant. 

Najszybszą i najmniej inwazyjną opcją naprawy okazała się wg mnie aktualizacja Ubuntu z Trusty na Xenial.