### PR TITLE
Obsłużenie próby dodania odpowiedzi na zamknięte pytanie

### DIFF
--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -313,7 +313,7 @@ function set_category_description(idprefix)
 		var alertDiv = document.createElement('div');
 		alertDiv.id = 'spoj-alert';
 		alertDiv.innerHTML = 'Twoje pytanie dotyczy zadania z serwisu SPOJ?<br>Nie psuj zabawy innym - nie umieszczaj całego kodu i zapoznaj się z <a href="http://forum.pasja-informatyki.pl/90416/spoj-zasady-umieszczania-postow?show=90416#q90416" target="_blank">tym tematem</a>.';
-		alertDiv.classList.add('spoj-alert');
+		alertDiv.classList.add('post-submission-alert');
 
 		function detectSpoj(place, ev)
 		{

--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -785,6 +785,7 @@ function qa_ajax_error()
             const setCursorToAnnotationEnd = ( editor, ckeTxt ) => {
                 editor.focus();
 
+                // TODO: handle 'getRanges of null' error
                 const currentRange = editor.getSelection().getRanges()[ 0 ];
                 const ckeNode = new CKEDITOR.dom.node( ckeTxt );
                 const newRange = new CKEDITOR.dom.range( currentRange.document );

--- a/forum/qa-content/qa-question.js
+++ b/forum/qa-content/qa-question.js
@@ -106,41 +106,8 @@ function qa_submit_answer(questionid, elem)
 					}
 				});
 			} else if (lines[0]=='0') {
-				if (lines[1] === 'ALREADY_CLOSED') {
-					console.warn('lines: ', lines, ' /elem: ', elem);
-					qa_hide_waiting(elem);
-
-					const saveButton = elem;
-					saveButton.value = 'Zamień tą odpowiedź na komentarz do pytania';
-
-					const [, namePrefix] = [...saveButton.form.elements]
-						.find(e => e.name.includes('_'))
-						.name.split('_');
-
-					// a97_dotoc: 1
-					const doToc = document.createElement('input');
-					doToc.type = 'checkbox';
-					doToc.style.display = 'none';
-					doToc.name = `${namePrefix}_dotoc`;
-					doToc.id = doToc.name;
-					doToc.value = '1';
-
-					const commentOnSel = document.createElement('select');
-					commentOnSel.name = `${namePrefix}_dotoc`;
-					commentOnSel.style.display = 'none';
-
-					const questionId = location.pathname.split('/').find(Number);
-					// a97_commenton: 5
-					const commentOnOpt = document.createElement('option');
-					commentOnOpt.value = questionId;
-					commentOnOpt.style.display = 'none';
-
-					commentOnSel.appendChild(commentOnOpt);
-					saveButton.form.appendChild(commentOnSel);
-
-					const currentOnClick = saveButton.getAttribute('onclick').split(';');
-					const newOnClick = `qa_show_waiting_after(this, false); ${ currentOnClick.shift() };`;
-					saveButton.setAttribute('onclick', newOnClick);
+				if (lines[1] === 'ALREADY_CLOSED' /* TODO: handle case for already hidden question */) {
+					window.handleRefusedAnswer(elem);
 				} else {
 					document.forms['a_form'].submit();
 				}
@@ -346,6 +313,22 @@ function qa_form_params(formname)
 }
 
 function qa_scroll_page_to(scroll)
+
 {
 	$('html,body').animate({scrollTop: scroll}, 400);
+}
+
+function handleRefusedAnswer(submitButton) {
+	qa_hide_waiting(submitButton);
+	submitButton.disabled = true;
+
+	const answerSubmissionError = document.createElement('div');
+	answerSubmissionError.innerHTML =
+		'Nie można dodać odpowiedzi, ponieważ pytanie zostało zamknięte.<br>Jeśli chcesz, to dodaj swój post w formie komentarza.';
+	answerSubmissionError.classList.add('post-submission-alert');
+
+	const emailNotificationOption = submitButton.form.elements.a_notify.parentNode.parentNode;
+	emailNotificationOption.remove();
+
+	submitButton.parentNode.insertBefore(answerSubmissionError, submitButton);
 }

--- a/forum/qa-content/qa-question.js
+++ b/forum/qa-content/qa-question.js
@@ -106,8 +106,44 @@ function qa_submit_answer(questionid, elem)
 					}
 				});
 			} else if (lines[0]=='0') {
-				document.forms['a_form'].submit();
+				if (lines[1] === 'ALREADY_CLOSED') {
+					console.warn('lines: ', lines, ' /elem: ', elem);
+					qa_hide_waiting(elem);
 
+					const saveButton = elem;
+					saveButton.value = 'Zamień tą odpowiedź na komentarz do pytania';
+
+					const [, namePrefix] = [...saveButton.form.elements]
+						.find(e => e.name.includes('_'))
+						.name.split('_');
+
+					// a97_dotoc: 1
+					const doToc = document.createElement('input');
+					doToc.type = 'checkbox';
+					doToc.style.display = 'none';
+					doToc.name = `${namePrefix}_dotoc`;
+					doToc.id = doToc.name;
+					doToc.value = '1';
+
+					const commentOnSel = document.createElement('select');
+					commentOnSel.name = `${namePrefix}_dotoc`;
+					commentOnSel.style.display = 'none';
+
+					const questionId = location.pathname.split('/').find(Number);
+					// a97_commenton: 5
+					const commentOnOpt = document.createElement('option');
+					commentOnOpt.value = questionId;
+					commentOnOpt.style.display = 'none';
+
+					commentOnSel.appendChild(commentOnOpt);
+					saveButton.form.appendChild(commentOnSel);
+
+					const currentOnClick = saveButton.getAttribute('onclick').split(';');
+					const newOnClick = `qa_show_waiting_after(this, false); ${ currentOnClick.shift() };`;
+					saveButton.setAttribute('onclick', newOnClick);
+				} else {
+					document.forms['a_form'].submit();
+				}
 			} else {
 				qa_ajax_error();
 			}

--- a/forum/qa-content/qa-question.js
+++ b/forum/qa-content/qa-question.js
@@ -106,8 +106,14 @@ function qa_submit_answer(questionid, elem)
 					}
 				});
 			} else if (lines[0]=='0') {
-				if (lines[1] === 'ALREADY_CLOSED' /* TODO: handle case for already hidden question */) {
-					window.handleRefusedAnswer(elem);
+				const [, answerRefuseReason ] = lines;
+
+				if (answerRefuseReason === 'ALREADY_CLOSED' || answerRefuseReason === 'UNAVAILABLE') {
+					window.handleRefusedPost({
+						postType: 'answer',
+						postRefuseReason: answerRefuseReason,
+						submitButton: elem
+					});
 				} else {
 					document.forms['a_form'].submit();
 				}
@@ -142,7 +148,19 @@ function qa_submit_comment(questionid, parentid, elem) {
 					}
 				});
 		} else if (lines[0] == '0') {
-			document.forms['c_form_' + parentid].submit();
+			const [, commentRefuseReason] = lines;
+
+			if (commentRefuseReason === 'UNAVAILABLE') {
+				window.handleRefusedPost({
+					postType: 'comment',
+					postRefuseReason: commentRefuseReason,
+					parentId: parentid,
+					parentPostIsQuestion: questionid === parentid,
+					submitButton: elem
+				});
+			} else {
+				document.forms['c_form_' + parentid].submit();
+			}
 		} else {
 			qa_ajax_error();
 		}
@@ -318,17 +336,44 @@ function qa_scroll_page_to(scroll)
 	$('html,body').animate({scrollTop: scroll}, 400);
 }
 
-function handleRefusedAnswer(submitButton) {
-	qa_hide_waiting(submitButton);
+function handleRefusedPost({ submitButton, postRefuseReason, postType, parentId, parentPostIsQuestion }) {
 	submitButton.disabled = true;
 
-	const answerSubmissionError = document.createElement('div');
-	answerSubmissionError.innerHTML =
-		'Nie można dodać odpowiedzi, ponieważ pytanie zostało zamknięte.<br>Jeśli chcesz, to dodaj swój post w formie komentarza.';
-	answerSubmissionError.classList.add('post-submission-alert');
+	hideEmailNotificationOption();
+	showSubmissionError();
+	qa_hide_waiting(submitButton);
 
-	const emailNotificationOption = submitButton.form.elements.a_notify.parentNode.parentNode;
-	emailNotificationOption.remove();
+	function showSubmissionError() {
+		const postSubmissionError = document.createElement('div');
+		postSubmissionError.innerHTML = getSubmissionErrorContent();
+		postSubmissionError.classList.add('post-submission-alert');
 
-	submitButton.parentNode.insertBefore(answerSubmissionError, submitButton);
+		submitButton.parentNode.insertBefore(postSubmissionError, submitButton);
+	}
+
+	function hideEmailNotificationOption() {
+		const formNotifyElementName = parentId ? `c${ parentId }_notify` : 'a_notify';
+		const emailNotificationOption = submitButton.form.elements[formNotifyElementName].parentNode.parentNode;
+		emailNotificationOption.remove();
+	}
+
+	function getSubmissionErrorContent() {
+		const postErrorDescription = postType === 'comment' ?
+			'Nie można dodać komentarza.' :
+			'Nie można dodać odpowiedzi.';
+		const submissionErrorContent = {
+			ALREADY_CLOSED: 'Nie można dodać odpowiedzi, ponieważ pytanie zostało zamknięte.<br>Jeśli chcesz, to dodaj swój post w formie komentarza.',
+			UNAVAILABLE: `${ postErrorDescription } ${ getPostRelationDescription() }`
+		};
+
+		return submissionErrorContent[postRefuseReason];
+	}
+
+	function getPostRelationDescription() {
+		if (postType === 'comment') {
+			return parentPostIsQuestion ? 'Pytanie nie jest już dostępne.' : 'Odpowiedź nie jest już dostępna.';
+		} else {
+			return 'Temat nie jest już dostępny.';
+		}
+	}
 }

--- a/forum/qa-include/ajax/answer.php
+++ b/forum/qa-include/ajax/answer.php
@@ -95,7 +95,7 @@
 	}
 
 
-	echo "QA_AJAX_RESPONSE\n0\n"; // fall back to non-Ajax submission if there were any problems
+	echo "QA_AJAX_RESPONSE\n0\nALREADY_CLOSED"; // fall back to non-Ajax submission if there were any problems
 
 
 /*

--- a/forum/qa-include/ajax/answer.php
+++ b/forum/qa-include/ajax/answer.php
@@ -1,103 +1,88 @@
 <?php
 /*
-	Question2Answer by Gideon Greenspan and contributors
-	http://www.question2answer.org/
+    Question2Answer by Gideon Greenspan and contributors
+    http://www.question2answer.org/
 
-	File: qa-include/qa-ajax-answer.php
-	Description: Server-side response to Ajax create answer requests
+    File: qa-include/qa-ajax-answer.php
+    Description: Server-side response to Ajax create answer requests
 
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
 
-	This program is free software; you can redistribute it and/or
-	modify it under the terms of the GNU General Public License
-	as published by the Free Software Foundation; either version 2
-	of the License, or (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-
-	More about this license: http://www.question2answer.org/license.php
+    More about this license: http://www.question2answer.org/license.php
 */
 
-	require_once QA_INCLUDE_DIR.'app/users.php';
-	require_once QA_INCLUDE_DIR.'app/limits.php';
-	require_once QA_INCLUDE_DIR.'db/selects.php';
+require_once QA_INCLUDE_DIR . 'app/users.php';
+require_once QA_INCLUDE_DIR . 'app/limits.php';
+require_once QA_INCLUDE_DIR . 'db/selects.php';
 
+// Load relevant information about this question
+$questionid = qa_post_text('a_questionid');
+$userid = qa_get_logged_in_userid();
 
-//	Load relevant information about this question
+[$question, $childposts] = qa_db_select_with_pending(
+    qa_db_full_post_selectspec($userid, $questionid),
+    qa_db_full_child_posts_selectspec($userid, $questionid)
+);
 
-	$questionid=qa_post_text('a_questionid');
-	$userid=qa_get_logged_in_userid();
+// Check if the question exists, is not hidden, and whether the user has permission to do this
+if (isset($question['basetype']) && $question['type'] === 'Q'
+    && !qa_user_post_permit_error('permit_post_a', $question, QA_LIMIT_ANSWERS)
+) {
+    if ($question['closedbyid'] !== null) {
+        echo "QA_AJAX_RESPONSE\n0\nALREADY_CLOSED";
 
-	list($question, $childposts)=qa_db_select_with_pending(
-		qa_db_full_post_selectspec($userid, $questionid),
-		qa_db_full_child_posts_selectspec($userid, $questionid)
-	);
+        return;
+    }
 
+    require_once QA_INCLUDE_DIR . 'app/captcha.php';
+    require_once QA_INCLUDE_DIR . 'app/format.php';
+    require_once QA_INCLUDE_DIR . 'app/post-create.php';
+    require_once QA_INCLUDE_DIR . 'app/cookies.php';
+    require_once QA_INCLUDE_DIR . 'pages/question-view.php';
+    require_once QA_INCLUDE_DIR . 'pages/question-submit.php';
 
-//	Check if the question exists, is not closed, and whether the user has permission to do this
+    // Try to create the new answer
+    $usecaptcha = qa_user_use_captcha(qa_user_level_for_post($question));
+    $answers = qa_page_q_load_as($question, $childposts);
+    $answerid = qa_page_q_add_a_submit($question, $answers, $usecaptcha, $in, $errors);
 
-	if ((@$question['basetype']=='Q') && (!isset($question['closedbyid'])) && !qa_user_post_permit_error('permit_post_a', $question, QA_LIMIT_ANSWERS)) {
-		require_once QA_INCLUDE_DIR.'app/captcha.php';
-		require_once QA_INCLUDE_DIR.'app/format.php';
-		require_once QA_INCLUDE_DIR.'app/post-create.php';
-		require_once QA_INCLUDE_DIR.'app/cookies.php';
-		require_once QA_INCLUDE_DIR.'pages/question-view.php';
-		require_once QA_INCLUDE_DIR.'pages/question-submit.php';
+    // If successful, page content will be updated via Ajax
+    if (isset($answerid)) {
+        $answer = qa_db_select_with_pending(qa_db_full_post_selectspec($userid, $answerid));
+        $question = $question + qa_page_q_post_rules($question, null, null, $childposts); // array union
+        $answer = $answer + qa_page_q_post_rules($answer, $question, $answers, null);
+        $usershtml = qa_userids_handles_html([$answer], true);
+        $a_view = qa_page_q_answer_view($question, $answer, false, $usershtml, false);
 
+        $themeclass = qa_load_theme_class(qa_get_site_theme(), 'ajax-answer', null, null);
+        $themeclass->initialize();
 
-	//	Try to create the new answer
+        echo "QA_AJAX_RESPONSE\n1\n";
 
-		$usecaptcha=qa_user_use_captcha(qa_user_level_for_post($question));
-		$answers=qa_page_q_load_as($question, $childposts);
-		$answerid=qa_page_q_add_a_submit($question, $answers, $usecaptcha, $in, $errors);
+        // Send back whether the 'answer' button should still be visible
+        echo (int)qa_opt('allow_multi_answers') . "\n";
 
-	//	If successful, page content will be updated via Ajax
+        // Send back the count of answers
+        $countanswers = $question['acount'] + 1;
+        if ($countanswers == 1) {
+            echo qa_lang_html('question/1_answer_title') . "\n";
+        } else {
+            echo qa_lang_html_sub('question/x_answers_title', $countanswers) . "\n";
+        }
 
-		if (isset($answerid)) {
-			$answer=qa_db_select_with_pending(qa_db_full_post_selectspec($userid, $answerid));
+        // Send back the HTML
+        $themeclass->a_list_item($a_view);
 
-			$question=$question+qa_page_q_post_rules($question, null, null, $childposts); // array union
-			$answer=$answer+qa_page_q_post_rules($answer, $question, $answers, null);
+        return;
+    }
+}
 
-			$usershtml=qa_userids_handles_html(array($answer), true);
-
-			$a_view=qa_page_q_answer_view($question, $answer, false, $usershtml, false);
-
-			$themeclass=qa_load_theme_class(qa_get_site_theme(), 'ajax-answer', null, null);
-			$themeclass->initialize();
-
-			echo "QA_AJAX_RESPONSE\n1\n";
-
-
-		//	Send back whether the 'answer' button should still be visible
-
-			echo (int)qa_opt('allow_multi_answers')."\n";
-
-
-		//	Send back the count of answers
-
-			$countanswers=$question['acount']+1;
-
-			if ($countanswers==1)
-				echo qa_lang_html('question/1_answer_title')."\n";
-			else
-				echo qa_lang_html_sub('question/x_answers_title', $countanswers)."\n";
-
-
-		//	Send back the HTML
-
-			$themeclass->a_list_item($a_view);
-
-			return;
-		}
-	}
-
-
-	echo "QA_AJAX_RESPONSE\n0\nALREADY_CLOSED"; // fall back to non-Ajax submission if there were any problems
-
-
-/*
-	Omit PHP closing tag to help avoid accidental output
-*/
+echo "QA_AJAX_RESPONSE\n0\nUNAVAILABLE"; // fall back to non-Ajax submission if there were any problems

--- a/forum/qa-include/ajax/answer.php
+++ b/forum/qa-include/ajax/answer.php
@@ -57,8 +57,8 @@ if (isset($question['basetype']) && $question['type'] === 'Q'
     // If successful, page content will be updated via Ajax
     if (isset($answerid)) {
         $answer = qa_db_select_with_pending(qa_db_full_post_selectspec($userid, $answerid));
-        $question = $question + qa_page_q_post_rules($question, null, null, $childposts); // array union
-        $answer = $answer + qa_page_q_post_rules($answer, $question, $answers, null);
+        $question = array_merge($question, qa_page_q_post_rules($question, null, null, $childposts));
+        $answer = array_merge($answer, qa_page_q_post_rules($answer, $question, $answers, null));
         $usershtml = qa_userids_handles_html([$answer], true);
         $a_view = qa_page_q_answer_view($question, $answer, false, $usershtml, false);
 

--- a/forum/qa-include/ajax/comment.php
+++ b/forum/qa-include/ajax/comment.php
@@ -47,7 +47,7 @@ $userid = qa_get_logged_in_userid();
 
 // Check if the question and parent exist, and whether the user has permission to do this
 if (isset($question['basetype'], $parent['basetype'])
-    && $question['basetype'] === 'Q' && ($parent['basetype'] === 'Q' || @$parent['basetype'] === 'A')
+    && $question['type'] === 'Q' && ($parent['type'] === 'Q' || $parent['type'] === 'A')
     && !qa_user_post_permit_error('permit_post_c', $parent, QA_LIMIT_COMMENTS)
 ) {
     require_once QA_INCLUDE_DIR . 'app/captcha.php';
@@ -65,16 +65,16 @@ if (isset($question['basetype'], $parent['basetype'])
     // If successful, page content will be updated via Ajax
     if (isset($commentid)) {
         $children = qa_db_select_with_pending(qa_db_full_child_posts_selectspec($userid, $parentid));
-        $parent = $parent + qa_page_q_post_rules(
+        $parent = array_merge($parent, qa_page_q_post_rules(
             $parent,
             ($questionid == $parentid) ? null : $question,
             null,
             $children
-        );
+        ));
         // in theory we should retrieve the parent's siblings for the above, but they're not going to be relevant
 
         foreach ($children as $key => $child) {
-            $children[$key] = $child + qa_page_q_post_rules($child, $parent, $children, null);
+            $children[$key] = array_merge($child, qa_page_q_post_rules($child, $parent, $children, null));
         }
         $usershtml = qa_userids_handles_html($children, true);
         qa_sort_by($children, 'created');
@@ -100,4 +100,4 @@ if (isset($question['basetype'], $parent['basetype'])
     }
 }
 
-	echo "QA_AJAX_RESPONSE\n0\nUNAVAILABLE"; // fall back to non-Ajax submission if there were any problems
+echo "QA_AJAX_RESPONSE\n0\nUNAVAILABLE"; // fall back to non-Ajax submission if there were any problems

--- a/forum/qa-include/ajax/comment.php
+++ b/forum/qa-include/ajax/comment.php
@@ -100,4 +100,4 @@ if (isset($question['basetype'], $parent['basetype'])
     }
 }
 
-echo "QA_AJAX_RESPONSE\n0\n"; // fall back to non-Ajax submission if there were any problems
+	echo "QA_AJAX_RESPONSE\n0\nUNAVAILABLE"; // fall back to non-Ajax submission if there were any problems

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -1975,12 +1975,14 @@ input[type="submit"], button {
 	background: #27ae60 none;
 }
 
-.qa-form-tall-button-answer[disabled] {
-	background: #117964;
+.qa-form-tall-button-answer[disabled],
+.qa-form-tall-button-comment[disabled] {
+	background: #0a5d5e;
 	color: darkgrey;
 }
 
-.qa-form-tall-button-answer[disabled]:hover {
+.qa-form-tall-button-answer[disabled]:hover,
+.qa-form-tall-button-comment[disabled]:hover {
 	cursor: not-allowed;
 	background: #0a5d5e;
 }
@@ -4578,7 +4580,7 @@ a.sidebarnav:hover {
 {
 	border: 2px solid red;
 	color: red;
-	padding: 5px 0;
+	padding: 15px 0;
 	margin: 5px 0;
 	text-align: center;
 	font-weight: bold;

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -1974,6 +1974,17 @@ input[type="submit"], button {
 .qa-form-tall-button-ask, .qa-form-tall-button-answer {
 	background: #27ae60 none;
 }
+
+.qa-form-tall-button-answer[disabled] {
+	background: #117964;
+	color: darkgrey;
+}
+
+.qa-form-tall-button-answer[disabled]:hover {
+	cursor: not-allowed;
+	background: #0a5d5e;
+}
+
 .qa-form-tall-button-save:hover, .qa-form-tall-button-save:focus,
 .qa-form-wide-button-save:hover, .qa-form-wide-button-save:focus,
 .qa-form-wide-button-saverecalc:hover, .qa-form-wide-button-saverecalc:focus,
@@ -4562,13 +4573,13 @@ a.sidebarnav:hover {
 {
 	color: #2ecc71;
 }
-/* for SPOJ detection */
-.spoj-alert
+
+.post-submission-alert
 {
 	border: 2px solid red;
 	color: red;
 	padding: 5px 0;
-	margin-top: 5px;
+	margin: 5px 0;
 	text-align: center;
 	font-weight: bold;
 	line-height: 20px;


### PR DESCRIPTION
Fix do issue #195 .

Treść odpowiedzi - gdy w międzyczasie **pytanie zostało zamknięte** - nie jest już usuwana. Zamiast tego pokazywany jest komunikat, że pytanie zostało zamknięte i użytkownik może dodać post w formie komentarza. Dodatkowo blokowany jest przycisk zapisania odpowiedzi.

Pozostaje kwestia naprawy obsługi dodania odpowiedzi i komentarza do **ukrytego pytania** - tego nie udało mi się namierzyć w backendzie. Natomiast, z tego co zauważyłem, to jeśli backend zwróciłby odpowiednią odpowiedź dla takiego przypadku, to po stronie frontu wystarczy dopisać warunek do już istniejącego dla przypadku zamkniętego pytania i zmodyfikować treść komunikatu (lub uogólnić ją, aby pasowała do obu przypadków).

**Screen komunikatu:**

![Komunikat o nieudanym dodaniu odpowiedzi](https://user-images.githubusercontent.com/18393526/85130763-d4b71300-b235-11ea-9aa3-076138ae4d30.png)
