### PR TITLE
Poprawka do dodawania komentarzy - kolorowanie kodu oraz wyświetlanie ostatnich komentarzy

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -310,7 +310,7 @@ function qa_ajax_error()
 
         let codeBlocks = [];
 
-        if (!chosenCodeBlocks) {
+        if (!chosenCodeBlocks || !chosenCodeBlocks.length) {
             const blocksSelector = insidePreview ? '.post-preview-parent .syntaxhighlighter' : '.syntaxhighlighter';
             codeBlocks = document.querySelectorAll(blocksSelector);
 

--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -322,7 +322,13 @@ function qa_ajax_error()
             codeBlocks = chosenCodeBlocks;
         }
 
-        codeBlocks.forEach(processBlock);
+        codeBlocks.forEach((codeBlock) => {
+            const codeBlockPrevElemSibling = codeBlock.previousElementSibling;
+
+            if (!codeBlockPrevElemSibling || !codeBlockPrevElemSibling.classList.contains('syntaxhighlighter-block-bar')) {
+                processBlock(codeBlock);
+            }
+        });
 
         function processBlock(codeBlock) {
             const blockBar = document.createElement('div');

--- a/forum/qa-content/qa-question.js
+++ b/forum/qa-content/qa-question.js
@@ -73,12 +73,9 @@ function qa_toggle_element(elem)
 function qa_submit_answer(questionid, elem)
 {
 	var params=qa_form_params('a_form');
-
 	params.a_questionid=questionid;
 
-	qa_ajax_post('answer', params,
-		function(lines) {
-
+	qa_ajax_post('answer', params, function(lines) {
 			if (lines[0]=='1') {
 				if (lines[1]<1) {
 					var b=document.getElementById('q_doanswer');
@@ -86,32 +83,34 @@ function qa_submit_answer(questionid, elem)
 						b.style.display='none';
 				}
 
-				var t=document.getElementById('a_list_title');
-				qa_set_inner_html(t, 'a_list_title', lines[2]);
-				qa_reveal(t, 'a_list_title');
+				const answerListTitle = document.getElementById('a_list_title');
+				qa_set_inner_html(answerListTitle, 'a_list_title', lines[2]);
+				qa_reveal(answerListTitle, 'a_list_title');
 
-				var e=document.createElement('div');
-				e.innerHTML=lines.slice(3).join("\n");
+				const answerWrapper = document.createElement('div');
+				answerWrapper.innerHTML = lines.slice(3).join("\n");
 
-				var c=e.firstChild;
-				c.style.display='none';
+				const answerItem = answerWrapper.firstChild;
+				answerItem.style.display='none';
 
-				var l=document.getElementById('a_list');
-				l.insertBefore(c, l.firstChild);
+				const answerList = document.getElementById('a_list');
+				answerList.insertBefore(answerItem, answerList.firstChild);
 
-				var a=document.getElementById('anew');
-				a.qa_disabled=true;
+				const answerFormParent = document.getElementById('anew');
+				answerFormParent.qa_disabled=true;
 
-				qa_reveal(c, 'answer');
-				qa_conceal(a, 'form');
-
+				qa_conceal(answerFormParent, 'form');
+				qa_reveal(answerItem, 'answer', () => {
+					if (typeof window.reloadBlocksOfCode === 'function') {
+						window.reloadBlocksOfCode(answerItem);
+					}
+				});
 			} else if (lines[0]=='0') {
 				document.forms['a_form'].submit();
 
 			} else {
 				qa_ajax_error();
 			}
-
 		}
 	);
 
@@ -188,8 +187,8 @@ function qa_submit_comment(questionid, parentid, elem) {
 		if (addedComment) {
 			addedComment.style.display = 'none';
 
-			return new Promise((onAnimationCompleted) => {
-				qa_reveal(addedComment, 'comment', onAnimationCompleted);
+			return new Promise((onCommentShown) => {
+				qa_reveal(addedComment, 'comment', onCommentShown);
 			});
 		}
 	}

--- a/forum/qa-content/qa-question.js
+++ b/forum/qa-content/qa-question.js
@@ -131,9 +131,14 @@ function qa_submit_comment(questionid, parentid, elem) {
 
 	function onSuccess(lines) {
 		if (lines[0] == '1') {
-			updateCommentsList(lines);
+			const updatedCommentsList = updateCommentsList(lines);
 			updateFormState();
-			revealNewComment(lines[1]);
+			revealNewComment(lines[1])
+				.then(() => {
+					if (typeof window.reloadBlocksOfCode === 'function') {
+						window.reloadBlocksOfCode(updatedCommentsList);
+					}
+				});
 		} else if (lines[0] == '0') {
 			document.forms['c_form_' + parentid].submit();
 		} else {
@@ -162,15 +167,14 @@ function qa_submit_comment(questionid, parentid, elem) {
 				newestComment.style.display = 'none';
 			}
 
-			newCommentsTempParent
-				.querySelectorAll('[class*="brush:"]')
-				.forEach(newComment => SyntaxHighlighter.highlight({}, newComment));
 			commentsList.append(...newCommentsTempParent.children);
 		} else {
 			commentsList.innerHTML = newComments;
 		}
 
 		commentsList.style.display = '';
+
+		return commentsList;
 	}
 
 	function updateFormState() {
@@ -183,7 +187,10 @@ function qa_submit_comment(questionid, parentid, elem) {
 		const addedComment = document.getElementById(commentId);
 		if (addedComment) {
 			addedComment.style.display = 'none';
-			qa_reveal(addedComment, 'comment');
+
+			return new Promise((onAnimationCompleted) => {
+				qa_reveal(addedComment, 'comment', onAnimationCompleted);
+			});
 		}
 	}
 

--- a/forum/qa-content/qa-question.js
+++ b/forum/qa-content/qa-question.js
@@ -148,6 +148,9 @@ function qa_submit_comment(questionid, parentid, elem) {
 					newestComment.style.display = 'none';
 				}
 
+				newCommentsTempParent
+					.querySelectorAll('[class*="brush:"]')
+					.forEach(newComment => SyntaxHighlighter.highlight({}, newComment));
 				commentsList.append(...newCommentsTempParent.children);
 			} else {
 				commentsList.innerHTML = newComments;

--- a/forum/qa-include/ajax/comment.php
+++ b/forum/qa-include/ajax/comment.php
@@ -24,6 +24,16 @@
 	require_once QA_INCLUDE_DIR.'app/limits.php';
 	require_once QA_INCLUDE_DIR.'db/selects.php';
 
+	function find_next_comment_id($last_id, $all_ids)
+    {
+        foreach ($all_ids as $id) {
+            if ($id > $last_id) {
+                return $id;
+            }
+        }
+
+        return end($all_ids);
+    }
 
 //	Load relevant information about this question and the comment parent
 
@@ -90,8 +100,9 @@
 
 		//	Send back the HTML
 
-            $from_id = (int) qa_post_text('last_comment_id') + 1;
-            $index = array_search($from_id, array_keys($c_list['cs']));
+            $ids = array_keys($c_list['cs']);
+            $from_id = find_next_comment_id((int) qa_post_text('last_comment_id'), $ids);
+            $index = array_search($from_id, $ids);
             if ($index !== false) {
                 $c_list['cs'] = array_slice($c_list['cs'], $index, null, true);
             }

--- a/forum/qa-include/ajax/comment.php
+++ b/forum/qa-include/ajax/comment.php
@@ -90,7 +90,12 @@
 
 		//	Send back the HTML
 
-			$themeclass->c_list_items($c_list['cs']);
+            $from_id = (int) qa_post_text('last_comment_id') + 1;
+            $index = array_search($from_id, array_keys($c_list['cs']));
+            if ($index !== false) {
+                $c_list['cs'] = array_slice($c_list['cs'], $index, null, true);
+            }
+            $themeclass->c_list_items($c_list['cs']);
 
 			return;
 		}

--- a/forum/qa-include/ajax/comment.php
+++ b/forum/qa-include/ajax/comment.php
@@ -1,120 +1,103 @@
 <?php
 /*
-	Question2Answer by Gideon Greenspan and contributors
-	http://www.question2answer.org/
+    Question2Answer by Gideon Greenspan and contributors
+    http://www.question2answer.org/
 
-	File: qa-include/qa-ajax-comment.php
-	Description: Server-side response to Ajax create comment requests
+    File: qa-include/qa-ajax-comment.php
+    Description: Server-side response to Ajax create comment requests
 
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
 
-	This program is free software; you can redistribute it and/or
-	modify it under the terms of the GNU General Public License
-	as published by the Free Software Foundation; either version 2
-	of the License, or (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-
-	More about this license: http://www.question2answer.org/license.php
+    More about this license: http://www.question2answer.org/license.php
 */
 
-	require_once QA_INCLUDE_DIR.'app/users.php';
-	require_once QA_INCLUDE_DIR.'app/limits.php';
-	require_once QA_INCLUDE_DIR.'db/selects.php';
+require_once QA_INCLUDE_DIR . 'app/users.php';
+require_once QA_INCLUDE_DIR . 'app/limits.php';
+require_once QA_INCLUDE_DIR . 'db/selects.php';
 
-	function find_next_comment_id($last_id, $all_ids)
-    {
-        foreach ($all_ids as $id) {
-            if ($id > $last_id) {
-                return $id;
-            }
+function find_next_comment_id($last_id, $all_ids)
+{
+    foreach ($all_ids as $id) {
+        if ($id > $last_id) {
+            return $id;
         }
-
-        return end($all_ids);
     }
 
-//	Load relevant information about this question and the comment parent
+    return end($all_ids);
+}
 
-	$questionid=qa_post_text('c_questionid');
-	$parentid=qa_post_text('c_parentid');
-	$userid=qa_get_logged_in_userid();
+// Load relevant information about this question and the comment parent
+$questionid = qa_post_text('c_questionid');
+$parentid = qa_post_text('c_parentid');
+$userid = qa_get_logged_in_userid();
 
-	list($question, $parent, $children)=qa_db_select_with_pending(
-		qa_db_full_post_selectspec($userid, $questionid),
-		qa_db_full_post_selectspec($userid, $parentid),
-		qa_db_full_child_posts_selectspec($userid, $parentid)
-	);
+[$question, $parent, $children] = qa_db_select_with_pending(
+    qa_db_full_post_selectspec($userid, $questionid),
+    qa_db_full_post_selectspec($userid, $parentid),
+    qa_db_full_child_posts_selectspec($userid, $parentid)
+);
 
+// Check if the question and parent exist, and whether the user has permission to do this
+if (isset($question['basetype'], $parent['basetype'])
+    && $question['basetype'] === 'Q' && ($parent['basetype'] === 'Q' || @$parent['basetype'] === 'A')
+    && !qa_user_post_permit_error('permit_post_c', $parent, QA_LIMIT_COMMENTS)
+) {
+    require_once QA_INCLUDE_DIR . 'app/captcha.php';
+    require_once QA_INCLUDE_DIR . 'app/format.php';
+    require_once QA_INCLUDE_DIR . 'app/post-create.php';
+    require_once QA_INCLUDE_DIR . 'app/cookies.php';
+    require_once QA_INCLUDE_DIR . 'pages/question-view.php';
+    require_once QA_INCLUDE_DIR . 'pages/question-submit.php';
+    require_once QA_INCLUDE_DIR . 'util/sort.php';
 
-//	Check if the question and parent exist, and whether the user has permission to do this
+    // Try to create the new comment
+    $usecaptcha = qa_user_use_captcha(qa_user_level_for_post($question));
+    $commentid = qa_page_q_add_c_submit($question, $parent, $children, $usecaptcha, $in, $errors);
 
-	if (
-		(@$question['basetype']=='Q') &&
-		((@$parent['basetype']=='Q') || (@$parent['basetype']=='A')) &&
-		!qa_user_post_permit_error('permit_post_c', $parent, QA_LIMIT_COMMENTS))
-	{
-		require_once QA_INCLUDE_DIR.'app/captcha.php';
-		require_once QA_INCLUDE_DIR.'app/format.php';
-		require_once QA_INCLUDE_DIR.'app/post-create.php';
-		require_once QA_INCLUDE_DIR.'app/cookies.php';
-		require_once QA_INCLUDE_DIR.'pages/question-view.php';
-		require_once QA_INCLUDE_DIR.'pages/question-submit.php';
-		require_once QA_INCLUDE_DIR.'util/sort.php';
+    // If successful, page content will be updated via Ajax
+    if (isset($commentid)) {
+        $children = qa_db_select_with_pending(qa_db_full_child_posts_selectspec($userid, $parentid));
+        $parent = $parent + qa_page_q_post_rules(
+            $parent,
+            ($questionid == $parentid) ? null : $question,
+            null,
+            $children
+        );
+        // in theory we should retrieve the parent's siblings for the above, but they're not going to be relevant
 
+        foreach ($children as $key => $child) {
+            $children[$key] = $child + qa_page_q_post_rules($child, $parent, $children, null);
+        }
+        $usershtml = qa_userids_handles_html($children, true);
+        qa_sort_by($children, 'created');
+        $c_list = qa_page_q_comment_follow_list($question, $parent, $children, true, $usershtml, false, null);
 
-	//	Try to create the new comment
+        $themeclass = qa_load_theme_class(qa_get_site_theme(), 'ajax-comments', null, null);
+        $themeclass->initialize();
 
-		$usecaptcha=qa_user_use_captcha(qa_user_level_for_post($question));
-		$commentid=qa_page_q_add_c_submit($question, $parent, $children, $usecaptcha, $in, $errors);
+        // Return only new comments
+        $ids = array_keys($c_list['cs']);
+        $from_id = find_next_comment_id((int) qa_post_text('last_comment_id'), $ids);
+        $index = array_search($from_id, $ids);
+        if ($index !== false) {
+            $c_list['cs'] = array_slice($c_list['cs'], $index, null, true);
+        }
 
+        // Send back the ID of the new comment and HTML
+        echo "QA_AJAX_RESPONSE\n1\n";
+        echo qa_anchor('C', $commentid) . "\n";
+        $themeclass->c_list_items($c_list['cs']);
 
-	//	If successful, page content will be updated via Ajax
+        return;
+    }
+}
 
-		if (isset($commentid)) {
-			$children=qa_db_select_with_pending(qa_db_full_child_posts_selectspec($userid, $parentid));
-
-			$parent=$parent+qa_page_q_post_rules($parent, ($questionid==$parentid) ? null : $question, null, $children);
-				// in theory we should retrieve the parent's siblings for the above, but they're not going to be relevant
-
-			foreach ($children as $key => $child)
-				$children[$key]=$child+qa_page_q_post_rules($child, $parent, $children, null);
-
-			$usershtml=qa_userids_handles_html($children, true);
-
-			qa_sort_by($children, 'created');
-
-			$c_list=qa_page_q_comment_follow_list($question, $parent, $children, true, $usershtml, false, null);
-
-			$themeclass=qa_load_theme_class(qa_get_site_theme(), 'ajax-comments', null, null);
-			$themeclass->initialize();
-
-			echo "QA_AJAX_RESPONSE\n1\n";
-
-
-		//	Send back the ID of the new comment
-
-			echo qa_anchor('C', $commentid)."\n";
-
-
-		//	Send back the HTML
-
-            $ids = array_keys($c_list['cs']);
-            $from_id = find_next_comment_id((int) qa_post_text('last_comment_id'), $ids);
-            $index = array_search($from_id, $ids);
-            if ($index !== false) {
-                $c_list['cs'] = array_slice($c_list['cs'], $index, null, true);
-            }
-            $themeclass->c_list_items($c_list['cs']);
-
-			return;
-		}
-	}
-
-	echo "QA_AJAX_RESPONSE\n0\n"; // fall back to non-Ajax submission if there were any problems
-
-
-/*
-	Omit PHP closing tag to help avoid accidental output
-*/
+echo "QA_AJAX_RESPONSE\n0\n"; // fall back to non-Ajax submission if there were any problems


### PR DESCRIPTION
Poprawione zostały dwa problemy:

- w momencie dodania komentarza do listy, która była zwinięta (na górze widoczny przycisk "Pokaż X poprzednich komentarzy") powstawał efekt jakoby cała lista komentarzy została niepotrzebnie automatycznie rozwijana. Problemem była rozwlekła odpowiedź z serwera, który zwracał całą listę komentarzy z uwzględnieniem nowo dodanego. Poprawka po stronie serwera (wprowadzona przez @awaluk ) odczytuje ID ostatniego komentarza z requesta wysłanego z frontu, który jest widoczny na stronie i na tej podstawie zwraca, albo tylko dodany przez użytkownika komentarz, albo wraz z nim inne komentarze, które zostały dodane w trakcie gdy użytkownik pisał swój komentarz

- dodany post ma teraz kolorowany kod oraz zostaje mu nadana interaktywna belka (do tej pory trzeba było odświeżyć stronę)