### PR TITLE
2fa

### DIFF
--- a/forum/qa-plugin/q2a-googleauthenticator-login/composer.json
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "event15/q2a-googleauthenticator-login",
+    "type": "library",
+    "license": "GPLv2",
+    "authors": [
+        {
+            "name": "Marek Woś",
+            "email": "mwos@getresponse.com"
+        }
+    ],
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": {
+            "CodersCommunity\\": "src/"
+        }
+    },
+    "require": {
+        "robthree/twofactorauth": "dev-master"
+    }
+}

--- a/forum/qa-plugin/q2a-googleauthenticator-login/composer.lock
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/composer.lock
@@ -1,0 +1,71 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ffe70c5dd85e6617331f0646a1302812",
+    "packages": [
+        {
+            "name": "robthree/twofactorauth",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RobThree/TwoFactorAuth.git",
+                "reference": "a77e7d822343bb88112baef808839cfae7bc5abb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RobThree/TwoFactorAuth/zipball/a77e7d822343bb88112baef808839cfae7bc5abb",
+                "reference": "a77e7d822343bb88112baef808839cfae7bc5abb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "@stable"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RobThree\\Auth\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Janssen",
+                    "homepage": "http://robiii.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Two Factor Authentication",
+            "homepage": "https://github.com/RobThree/TwoFactorAuth",
+            "keywords": [
+                "Authentication",
+                "MFA",
+                "Multi Factor Authentication",
+                "Two Factor Authentication",
+                "authenticator",
+                "authy",
+                "php",
+                "tfa"
+            ],
+            "time": "2017-11-06T17:55:56+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "robthree/twofactorauth": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/forum/qa-plugin/q2a-googleauthenticator-login/metadata.json
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "Google Authenticator 2-factor authentication for Q2A",
+  "description": "This plugin provides a Google 2FA security for users on forum",
+  "version": "1.0",
+  "date": "2018-05-30",
+  "author": "Marek Woś",
+  "author_uri": "http://github.com/event15",
+  "license": "GPLv2",
+  "update_uri": "Web address for Q2A to check for updates",
+  "min_q2a": "1.7",
+  "min_php": "5.4",
+  "load_order": "Bootstrap moment in which the plugin will be loaded"
+}

--- a/forum/qa-plugin/q2a-googleauthenticator-login/q2a-googleauthenticator-layer.php
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/q2a-googleauthenticator-layer.php
@@ -1,0 +1,174 @@
+<?php
+
+require_once GOOGLEAUTHENTICATOR_BASIC_PATH . '/src/Init.php';
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+    public function doctype()
+    {
+        parent::doctype();
+
+        if ('account' === $this->request && true === (bool) qa_opt('googleauthenticator_login')) {
+            $content = [
+                'tags'    => 'method="post" action="' . qa_self_html() . '"',
+                'style'   => 'wide',
+                'title'   => qa_lang_html('plugin_2fa/title')
+            ];
+
+            $content += $this->enablePlugin();
+
+            $this->content['form_2fa'] = $content;
+            qa_html_theme_base::doctype();
+        }
+    }
+
+    private function getUserQuery($userId)
+    {
+        // Return the user with the specified userid (should return one user or null)
+        $users = qa_db_read_all_assoc(
+            qa_db_query_sub(
+                'SELECT us.userid, us.2fa_enabled, us.email, us.handle, us.2fa_change_date, up.points FROM ^users us LEFT JOIN ^userpoints up ON us.userid = up.userid WHERE us.userid=$',
+                $userId
+            )
+        );
+
+        return empty($users) ? null : $users[0];
+    }
+
+    /**
+     * This method enables 2fa on selected user.
+     *
+     * @param $userId
+     * @param $isEnabled
+     * @param $secret
+     * @param $recoveryCode
+     *
+     * @return mixed
+     */
+    private function updateUserEnable2FA($userId, $isEnabled, $secret = null, $recoveryCode = null)
+    {
+        $time      = new DateTime('now');
+        $formatter = new IntlDateFormatter('pl_PL', IntlDateFormatter::SHORT, IntlDateFormatter::SHORT);
+        $formatter->setPattern('EEEE, dd MMMM yyyy, HH:mm:ss');
+
+        $result = qa_db_query_sub(
+            'UPDATE ^users SET 2fa_enabled=#, 2fa_change_date=$, 2fa_secret=$, 2fa_recovery_code=$ WHERE userid=#',
+            $isEnabled,
+            $formatter->format($time),
+            $secret,
+            $recoveryCode,
+            $userId
+        );
+
+        if (true === $result) {
+            return $isEnabled;
+        }
+
+        user_error('Nie udało się włączyć autoryzacji dwuetapowej. Zgłoś ten problem administratorowi.');
+    }
+
+    private function enablePlugin()
+    {
+        $userAccount   = $this->getUser();
+        $userActive2fa = $userAccount['2fa_enabled'];
+
+        if (qa_clicked('doenable2fa')) {
+            $this->init = new Init();
+            $this->init->createSecret();
+            $recoveryCode = $this->init->getRandomRecoveryCode();
+            $secret = $this->init->getSecret();
+
+            $userActive2fa = $this->updateUserEnable2FA($userAccount['userid'], true, $secret, $recoveryCode);
+        } elseif (qa_clicked('dodisable2fa')) {
+            $userActive2fa = $this->updateUserEnable2FA($userAccount['userid'], false);
+        }
+
+        $userAccount = $this->getUser();
+        if (true === (bool) $userActive2fa) {
+
+            $result = $this->render2FAEnabledForm($userAccount['2fa_change_date']);
+
+            if (isset($this->init)) {
+                $note = qa_lang_html('plugin_2fa/2fa_data_info');
+                $note = str_replace('{{ QR_CODE }}', '<br><center><img src="' . $this->init->getQRCode() . '"></center><br>', $note);
+                $note = str_replace('{{ SECRET }}', '<code>' . $secret . '</code>', $note);
+                $note = str_replace('{{ RECOVERY_CODE }}', '<code>' . $recoveryCode . '</code>', $note);
+                $note = str_replace('{{ ERROR_START }}', '<br><div class="qa-error">', $note);
+                $note = str_replace('{{ ERROR_END }}', '</div><br>', $note);
+
+                $result['fields'][] = [
+                    'style' => 'tall',
+                    'type' => 'static',
+                    'note' => $note
+                ];
+            }
+
+        } else {
+            $result = $this->render2FADisabledForm($userAccount['2fa_change_date']);
+        }
+                
+        return $result;
+    }
+
+    private function render2FAEnabledForm($date)
+    {
+        return [
+            'fields'  => [
+                'old' => [
+                    'label' => qa_lang_html('plugin_2fa/plugin_is_enabled'),
+                    'tags'  => 'name="oldpassword" disabled',
+                    'value' => $date,
+                    'type'  => 'input'
+                ],
+            ],
+            'buttons' => [
+                'enable' => [
+                    'label' => qa_lang_html('plugin_2fa/disable_plugin')
+                ]
+            ],
+            'hidden'  => [
+                'dodisable2fa' => '1',
+                'code'         => qa_get_form_security_code('2faform')
+            ]
+        ];
+    }
+
+    private function render2FADisabledForm($date)
+    {
+        return [
+            'fields'  => [
+                'old' => [
+                    'label' => qa_lang_html('plugin_2fa/plugin_is_disabled'),
+                    'value' => '',
+                    'type'  => 'static'
+                ]
+            ],
+            'buttons' => [
+                'enable_2fa' => [
+                    'label' => qa_lang_html('plugin_2fa/enable_plugin')
+                ]
+            ],
+            'hidden'  => [
+                'doenable2fa' => '1',
+                'code'        => qa_get_form_security_code('2faform')
+            ]
+        ];
+    }
+
+    /**
+     * @return null
+     */
+    private function getUser()
+    {
+        $userId = qa_get_logged_in_userid();
+
+        if (!isset($userId)) {
+            qa_redirect('login');
+        }
+
+        $userAccount = $this->getUserQuery($userId);
+
+        return $userAccount;
+    }
+}
+

--- a/forum/qa-plugin/q2a-googleauthenticator-login/q2a-googleauthenticator-overrides.php
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/q2a-googleauthenticator-overrides.php
@@ -1,0 +1,82 @@
+<?php
+
+function qa_set_logged_in_user($userId, $handle = '', $remember = false, $source = null)
+{
+	require_once QA_INCLUDE_DIR . 'app/cookies.php';
+
+	qa_start_session();
+
+	if (!isset($userId)) {
+		// logout
+
+		qa_report_event(
+			'u_logout',
+			qa_get_logged_in_userid(),
+			qa_get_logged_in_handle(),
+			qa_cookie_get()
+		);
+
+		qa_clear_session_cookie();
+		qa_clear_session_user();
+
+		return;
+	}
+
+	// login
+
+	require_once QA_INCLUDE_DIR . 'db/selects.php';
+
+	$result = qa_db_read_all_assoc(qa_db_query_sub(
+		'SELECT 2fa_enabled FROM ^users WHERE userid = #',
+		$userId
+	));
+
+	if (count($result) != 1) {
+		echo 'Invalid num_rows';
+		die;
+	}
+
+	$usingTwoFactorAuth = (bool) $result[0]['2fa_enabled'];
+
+	if ($usingTwoFactorAuth && '2fa' !== $source) {
+		echo '
+<form method="post" id="form" action="./2fa-auth">
+	<input name="login" type="hidden" value="' . qa_post_text('emailhandle') . '">
+	<input name="password" type="hidden" value="' . qa_post_text('password') . '">
+	<input name="remember" type="hidden" value="' . qa_post_text('remember') . '">
+	<input name="redirect" type="hidden" value="' . $_GET['to'] . '">
+</form>
+Trwa przekierowanie...
+<script>
+document.getElementById("form").submit();
+</script>
+';
+		exit;
+	}
+
+	$userInfo = qa_db_single_select(
+		qa_db_user_account_selectspec(
+			$userId,
+			true
+		)
+	);
+
+	if (empty($userInfo['sessioncode']) || $source !== $userInfo['sessionsource'] && '2fa' !== $source) {
+		$sessionCode = qa_db_user_rand_sessioncode();
+		
+		qa_db_user_set(
+			$userId,
+			[
+				'sessioncode' => $sessionCode,
+				'sessionsource' => $sessionSource,
+			]
+		);
+	} else {
+		$sessionCode = $userInfo['sessioncode'];
+	}
+
+	qa_db_user_logged_in($userId, qa_remote_ip_address());
+	qa_set_session_cookie($handle, $sessionCode, $remember);
+
+	qa_report_event('u_login', $userId, $userInfo['handle'], qa_cookie_get());
+}

--- a/forum/qa-plugin/q2a-googleauthenticator-login/q2a-googleauthenticator-page-login.php
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/q2a-googleauthenticator-page-login.php
@@ -1,0 +1,169 @@
+<?php
+
+require_once GOOGLEAUTHENTICATOR_BASIC_PATH . '/src/Init.php';
+require_once QA_INCLUDE_DIR . 'app/users.php';
+require_once QA_INCLUDE_DIR . 'db/users.php';
+
+class q2a_googleauthenticator_page_login
+{
+	public function match_request($request): bool
+	{
+		return '2fa-auth' === $request;
+	}
+
+	public function process_request()
+	{
+		if (empty(qa_post_text('login')) || empty(qa_post_text('password'))) {
+			qa_redirect('');
+
+			return;
+		}
+
+		if (empty(qa_post_text('2fa_code'))) {
+			$content = qa_content_prepare();
+
+			$content['title'] = 'Logowanie dwuetapowe';
+			$content['form'] = $this->prepareTwoFactorAuthForm();
+
+			return $content;
+		}
+
+		$secret = qa_db_read_all_assoc(
+			qa_db_query_sub(
+				'SELECT 2fa_secret FROM ^users WHERE handle = $',
+				qa_post_text('login')
+			)
+		);
+
+		if (empty($secret)) {
+			// that would never occur...
+
+			echo 'Invalid secret.';
+			die;
+		}
+		$init = new Init($secret[0]['2fa_secret']);
+
+		$code = qa_post_text('2fa_code');
+		$login = qa_post_text('login');
+		$password = qa_post_text('password');
+
+		// @TODO: Fix it.
+
+		if ($init->verifyCode($code)) {
+			if ($this->checkLogin($login, $password)) {
+
+				$userId = qa_db_read_all_assoc(
+					qa_db_query_sub(
+						'SELECT userid FROM ^users WHERE handle = $',
+						$login
+					)
+				)[0]['userid'];
+
+				$this->login($userId, $login, (bool) qa_post_text('remember'), qa_post_text('redirect'));
+				return;
+			}
+		}
+
+		$recoveryCode = qa_db_read_all_assoc(
+			qa_db_query_sub(
+				'SELECT 2fa_recovery_code FROM ^users WHERE handle = $',
+				$login
+			)
+		)[0]['2fa_recovery_code'];
+
+		if ($code == $recoveryCode) {
+			// logged in with recovery code
+
+			if ($this->checkLogin($login, $password)) {
+				qa_db_query_sub(
+					'UPDATE ^users SET 2fa_recovery_code = NULL WHERE handle = $',
+					$login
+				);
+
+				$userId = qa_db_read_all_assoc(
+					qa_db_query_sub(
+						'SELECT userid FROM ^users WHERE handle = $',
+						$login
+					)
+				)[0]['userid'];
+				
+				$this->login($userId, $login, (bool) qa_post_text('remember'), 'NOTHING');
+
+				$content = qa_content_prepare();
+				$content['title'] = qa_lang_html('plugin_2fa/title');
+				$content['custom'] = qa_lang_html('plugin_2fa/recover_code_page_info');
+
+				return $content;
+			}
+		}
+
+		$content = qa_content_prepare();
+
+		$content['title'] = qa_lang_html('plugin_2fa/title');
+		$content['form'] = $this->prepareTwoFactorAuthForm();
+		$content['error'] = qa_lang_html('plugin_2fa/invalid_code');
+
+		return $content;
+	}
+
+	private function checkLogin($login, $password): bool
+	{
+		if (false !== strpos($login, '@')) {
+			$matchUsers = qa_db_user_find_by_email($login);
+		} else {
+			$matchUsers = qa_db_user_find_by_handle($login);
+		}
+
+		if (1 !== count($matchUsers)) {
+			return false;
+		}
+
+		$userInfo = qa_db_select_with_pending(qa_db_user_account_selectspec($matchUsers[0], true));
+
+		// I dont know what it does, it's copied from Q2A core
+		if (strtolower(qa_db_calc_passcheck($password, $userInfo['passsalt'])) == strtolower($userInfo['passcheck'])) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private function login($userId, $login, $remember = false, $redirectPath = null): void
+	{
+		qa_set_logged_in_user($userId, $login, $remember, '2fa');
+
+		if (null === $redirectPath) {
+			qa_redirect('');
+		} else if ('NOTHING' != $redirectPath) {
+			qa_redirect_raw(qa_path_to_root() . $redirectPath);
+		}
+	}
+
+	private function prepareTwoFactorAuthForm(): array
+	{
+		return [
+            'tags'    => 'method="post" action="' . qa_self_html() . '"',
+            'style'   => 'wide',
+            'title'   => qa_lang_html('plugin_2fa/title'),
+            'fields'  => [
+                'old' => [
+                    'label' => qa_lang_html('plugin_2fa/code_input'),
+                    'tags'  => 'name="2fa_code"',
+           	        'type'  => 'input'
+               	],
+            ],
+            'buttons' => [
+                'send' => [
+                    'label' => qa_lang_html('plugin_2fa/send')
+                ]
+            ],
+            'hidden'  => [
+            	'login'        => qa_post_text('login'),
+            	'password'     => qa_post_text('password'),
+            	'remember'     => qa_post_text('remember'),
+            	'redirect'     => qa_post_text('redirect'),
+                'code'         => qa_get_form_security_code('2faform'),
+            ]
+        ];
+	}
+}

--- a/forum/qa-plugin/q2a-googleauthenticator-login/qa-plugin.php
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/qa-plugin.php
@@ -1,0 +1,39 @@
+<?php
+/*
+    Plugin Name: Google Authenticator 2-factor authentication for Q2A
+    Plugin URI:
+    Plugin Description: This plugin provides a Google 2FA security for users on forum
+    Plugin Version: 1.0
+    Plugin Date: 2018-05-30
+    Plugin Author: Marek Woś
+    Plugin Author URI: http://github.com/event15
+    Plugin License: GPLv2
+    Plugin Minimum Question2Answer Version: 1.7
+    Plugin Update Check URI:
+*/
+
+use CodersCommunity\q2a_googleauthenticator_admin;
+use CodersCommunity\q2a_googleauthenticator_event;
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+    header('Location: ../../');
+    exit;
+}
+
+define('GOOGLEAUTHENTICATOR_BASIC_PATH', __DIR__);
+
+qa_register_plugin_phrases('src/i18n/q2a-googleauthenticator-lang-*.php', 'plugin_2fa');
+qa_register_plugin_layer('q2a-googleauthenticator-layer.php', 'Google 2FA Layer');
+qa_register_plugin_module(
+    'module',
+    'src/q2a-googleauthenticator-admin.php',
+    q2a_googleauthenticator_admin::class,
+    'q2a Google Authenticator Admin'
+);
+
+qa_register_plugin_overrides('q2a-googleauthenticator-overrides.php');
+qa_register_plugin_module('page', 'q2a-googleauthenticator-page-login.php', 'q2a_googleauthenticator_page_login', 'Google Authenticator Code');
+
+//qa_register_plugin_overrides('qa-open-overrides.php');
+//qa_register_plugin_module('page', 'qa-open-page-logins.php', 'qa_open_logins_page', 'Open Login Configuration');
+//qa_register_plugin_module('widget', 'qa-open-widget.php', 'qa_open_logins_widget', 'Open Login Providers');

--- a/forum/qa-plugin/q2a-googleauthenticator-login/src/Init.php
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/src/Init.php
@@ -1,0 +1,104 @@
+<?php
+
+require_once GOOGLEAUTHENTICATOR_BASIC_PATH . '/vendor/autoload.php';
+
+use RobThree\Auth\TwoFactorAuth;
+
+class Init
+{
+
+    private $auth;
+    private $secret;
+
+    public function __construct($secret = null)
+    {
+        $this->auth = new TwoFactorAuth('Forum Pasja Informatyki', 6, 30, 'sha512');
+        $this->secret = $secret;
+        $this->auth->ensureCorrectTime();
+    }
+
+    public function verifyCode($code): bool
+    {
+        return $this->auth->verifyCode($this->secret, $code, 5);
+    }
+
+    public function createSecret(): void
+    {
+        $this->secret = $this->auth->createSecret(160);
+    }
+
+    public function getSecret(): string
+    {
+        return $this->secret;
+    }
+
+    public function getCode()
+    {
+        return $this->auth->getCode($this->secret);
+    }
+
+    public function getQRCode(): string
+    {
+        return $this->auth->getQRCodeImageAsDataUri('Forum Pasja Informatyki', $this->secret);
+    }
+
+    public function getRandomRecoveryCode(): string
+    {
+        return $this->randomString(5) . '-' . $this->randomString(5);
+    }
+
+    public function getDebugInfo(): array 
+    {
+        $result = [
+            'style' => 'tall',
+            'type' => 'static',
+            'note' => 'Secret: ' . $this->secret . '<br>Kod: ' . $this->auth->getCode($this->secret) . '<br>Valid: ' . ((true === $this->auth->verifyCode($this->secret, $this->auth->getCode($this->secret))) ? 'OK' : 'FAIL') . '<br>Obrazek: <img src="' . $this->auth->getQRCodeImageAsDataUri('Pasja Informatyki', $this->secret) . '">'
+        ];
+
+        return $result;
+    }
+
+    // https://stackoverflow.com/a/31107425
+    /**
+     * Generate a random string, using a cryptographically secure 
+     * pseudorandom number generator (random_int)
+     *
+     * This function uses type hints now (PHP 7+ only), but it was originally
+     * written for PHP 5 as well.
+     * 
+     * For PHP 7, random_int is a PHP core function
+     * For PHP 5.x, depends on https://github.com/paragonie/random_compat
+     * 
+     * @param int $length      How many characters do we want?
+     * @param string $keyspace A string of all possible characters
+     *                         to select from
+     * @return string
+     */
+    public function randomString(
+        int $length = 64,
+        string $keyspace = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    ): string {
+        if ($length < 1) {
+            throw new \RangeException("Length must be a positive integer");
+        }
+        $pieces = [];
+        $max = mb_strlen($keyspace, '8bit') - 1;
+        for ($i = 0; $i < $length; ++$i) {
+            $pieces []= $keyspace[random_int(0, $max)];
+        }
+        return implode('', $pieces);
+    }
+}
+
+//$ok = new Init();
+
+/*
+ * TODO:
+ * 1. Generowanie secretu dla połączenia z 2FA
+ *   a) Strona przeznaczona do wygenerowania secretu powinna zawierać qr code
+ *   b) secret powinien zapisywać się w bazie danych do użytkownika
+ * 2. Logowanie przy pomocy kodu z google 2FA
+ *   a) należy pobrać informację, czy użytkownik wykorzystuje 2fa
+ *   b) należy pobrać secret zapisany w bazie secret
+ *   c) należy zweryfikować secret z kodem i poprawnie zalogować
+ */

--- a/forum/qa-plugin/q2a-googleauthenticator-login/src/i18n/q2a-googleauthenticator-lang-default.php
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/src/i18n/q2a-googleauthenticator-lang-default.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'title'                   => 'Weryfikacja dwuetapowa',
+    'plugin_is_enabled'       => 'Weryfikacja dwuetapowa jest włączona od ',
+    'plugin_is_disabled'      => 'Weryfikacja dwuetapowa jest wyłączona',
+    'enable_plugin'           => 'Włącz',
+    'disable_plugin'          => 'Wyłącz',
+
+    'default_auth' => '(Domyślna)',
+    'confirm'      => 'Gotowe',
+    'next'         => 'Dalej',
+    'cancel'       => 'Anuluj',
+    'generate'     => 'Wygeneruj',
+
+    'recover_code_page_info' => 'Zalogowałeś się z wykorzystaniem kodu awaryjnego. Nie jest on już aktywny. Jeśli nie możesz już logować się korzystając z weryfikacji dwuetapowej pamiętaj, aby w ustawieniach wyłączyć logowanie dwuetapowe. Inaczej nie będziesz mógł/mogła się już zalogować.',
+    '2fa_data_info'          => 'Właśnie włączyłeś weryfikację dwuetapową. To dobry krok na drodze do całkowitego zabezpieczenia Twojego konta. Aby skorzystać z weryfikacji dwuetapowej, zeskanuj ten kod QR swoim telefonem {{ QR_CODE }} {{ ERROR_START }}Nie możesz zeskanować kodu QR? Możesz też wpisać ten kod do swojej aplikacji (tzw. secret) {{ SECRET }}.{{ ERROR_END }}W razie sytuacji awaryjnej, w miejscu kodu z aplikacji możesz również wpisać ten kod zapasowy: {{ RECOVERY_CODE }}. Pamiętaj że jest on wykorzystywany w wyjątkowych sytuacjach i działa tylko na jedno logowanie - później bedziesz musial wygenerować nowy kod.',
+    'code_input'             => 'Kod weryfikacyjny:',
+    'send'                   => 'Wyślij',
+    'invalid_code'           => 'Błędny kod'
+
+];
+

--- a/forum/qa-plugin/q2a-googleauthenticator-login/src/q2a-googleauthenticator-admin.php
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/src/q2a-googleauthenticator-admin.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace CodersCommunity;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+class q2a_googleauthenticator_admin
+{
+    public function init_queries()
+    {
+        $isActive = qa_opt('googleauthenticator_login');
+        $result = null;
+
+        if (1 === $isActive) {
+            return $result;
+        }
+
+        $queries = [];
+
+        $columns = qa_db_read_all_values(qa_db_query_sub('describe ^users'));
+        if (!in_array('2fa_enabled', $columns)) {
+            $queries[] = 'ALTER TABLE ^users ADD `2fa_enabled` SMALLINT (1) DEFAULT 0';
+        }
+
+        if (!in_array('2fa_change_date', $columns)) {
+            $queries[] = 'ALTER TABLE ^users ADD `2fa_change_date` VARCHAR (80) DEFAULT 0';
+        }
+
+        if (!in_array('2fa_secret', $columns)) {
+            $queries[] =
+                'ALTER TABLE ^users ADD `2fa_secret` VARCHAR ( 80 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL';
+        }
+
+        if (!in_array('2fa_recovery_code', $columns)) {
+            $queries[] = 'ALTER TABLE ^users ADD `2fa_recovery_code` VARCHAR (11) DEFAULT 0';
+        }
+
+        if(count($queries)) {
+            $result = $queries;
+        }
+
+        // we're already set up
+        qa_opt('googleauthenticator_login', 1);
+
+        return $result;
+    }
+
+    public function admin_form()
+    {
+        $saved = false;
+
+        if (qa_clicked('2fa_save_button')) {
+            $enabled = qa_post_text('googleauthenticator_enable_plugin');
+            qa_opt('googleauthenticator_login', empty($enabled) ? 0 : 1);
+
+            $saved = true;
+        }
+
+            $form = [
+            'ok' => $saved ? 'Two factor preferences saved' : null,
+            'fields' => [[
+                'type' => 'checkbox',
+                'label' => qa_lang_html('plugin_2fa/disable_plugin_title'),
+                'value' => qa_opt('googleauthenticator_login') ? true : false,
+                'tags' => 'NAME="googleauthenticator_enable_plugin"'
+                ]
+            ],
+            'buttons' => [[
+                'label' => 'Save Changes',
+                'tags' => 'NAME="2fa_save_button"'
+                ]
+            ]
+        ];
+
+        return $form;
+    }
+}

--- a/forum/qa-plugin/q2a-googleauthenticator-login/src/q2a-googleauthenticator-overrides.php
+++ b/forum/qa-plugin/q2a-googleauthenticator-login/src/q2a-googleauthenticator-overrides.php
@@ -1,0 +1,82 @@
+<?php
+
+function qa_set_logged_in_user($userId, $handle = '', $remember = false, $source = null)
+{
+	require_once QA_INCLUDE_DIR . 'app/cookies.php';
+
+	qa_start_session();
+
+	if (!isset($userId)) {
+		// logout
+
+		qa_report_event(
+			'u_logout',
+			qa_get_logged_in_userid(),
+			qa_get_logged_in_handle(),
+			qa_cookie_get()
+		);
+
+		qa_clear_session_cookie();
+		qa_clear_session_user();
+
+		return;
+	}
+
+	// login
+
+	require_once QA_INCLUDE_DIR . 'db/selects.php';
+
+	$result = qa_db_read_all_assoc(qa_db_query_sub(
+		'SELECT 2fa_enabled FROM ^users WHERE userid = #',
+		$userId
+	));
+
+	if (count($result) !== 1) {
+		echo 'Invalid num_rows';
+		die;
+	}
+
+	$usingTwoFactorAuth = (bool) $result[0]['2fa_enabled'];
+	
+	if ($usingTwoFactorAuth) {
+/*		print_r('
+<form method="post" id="form" action="/2fa-auth">
+	<input name="login" value="' . qa_post_text('emailhandle') . '">
+	<input name="password" value="' . qa_post_text('password') . '">
+</form>
+Trwa przekierowanie...
+<script>
+document.getElementById("form").submit();
+</script>
+');
+		var_dump($_SERVER);*/
+		//qa_redirect('');
+		//return;
+	}
+
+	$userInfo = qa_db_single_select(
+		qa_db_user_account_selectspec(
+			$userId,
+			true
+		)
+	);
+
+	if (empty($userInfo['sessioncode']) || $source !== $userInfo['sessionsource']) {
+		$sessionCode = qa_db_user_rand_sessioncode();
+		
+		qa_db_user_set(
+			$userId,
+			[
+				'sessioncode' => $sessionCode,
+				'sessionsource' => $sessionSource,
+			]
+		);
+	} else {
+		$sessionCode = $userInfo['sessioncode'];
+	}
+
+	qa_db_user_logged_in($userId, qa_remote_ip_address());
+	qa_set_session_cookie($handle, $sessionCode, $remember);
+
+	qa_report_event('u_login', $userId, $userInfo['handle'], qa_cookie_get());
+}


### PR DESCRIPTION
Autoryzacja dwuetapowa z PRa #147 , dodałem trochę rzeczy, na razie oznaczam jako Draft bo moja aplikacja generuje inne kody niż chce plugin (natomiast kody zapasowe i generownaie działa dobrze), możliwe że to przez różnicę czasu albo coś innego. Później popatrzę.

Zastanawiam się nad dodaniem przycisku wyłączającego 2fa dla danego użytkownika, który jest widoczny tylko dla administratorów (w razie zgubienia telefonu i kodu zapasowego, po ręcznej weryfikacji będzie można bez ingerencji w bazę danych wyłączyć 2fa)