### PR TITLE
[fix] Wymuszenie centrowania tytułu w bloczku z kodem

### DIFF
--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4615,6 +4615,20 @@ pre[class*="brush:"]
 	/* Used !important to override default SH styles */
 	text-align: center !important;
 	font-weight: bold !important;
+	padding-left: 0 !important;
+	position: absolute !important;
+	left: 50% !important;
+	width: 100% !important;
+
+	transform: translateX(-50%);
+	z-index: 1;
+	white-space: pre;
+}
+
+.syntaxhighlighter caption + ::before {
+	content: '';
+	display: block;
+	height: 33px;
 }
 
 .syntaxhighlighter.collapsed-block,
@@ -4712,7 +4726,7 @@ pre[class*="brush:"]::after
 .syntaxhighlighter-collapsible-button
 {
 	position: relative;
-	width: 55px;
+	width: 65px;
 	height: 20px;
 	display: block;
 	margin: 0 auto;
@@ -4739,7 +4753,7 @@ pre[class*="brush:"]::after
 	background: white;
 
 	--vertical-alignment-value: -0.5px;
-	--horizontal-alignment-value: 5px;
+	--horizontal-alignment-value: 10px;
 }
 
 .syntaxhighlighter-collapsible-button.expanded-state::before,


### PR DESCRIPTION
Problem został wykryty w pytaniu: https://forum.pasja-informatyki.pl/499333/blad-cannot-declare-class-app-databases

W bloczkach z kodem, które są przewijalne w poziomie, tytuł jest niewłaściwie centrowany:
![screen](https://user-images.githubusercontent.com/18393526/87342578-c6fe6000-c54b-11ea-8523-670f36341392.png)


**Po poprawkach:**

![screen](https://user-images.githubusercontent.com/18393526/87342425-856db500-c54b-11ea-9699-3d090c1a000c.png)

Przy okazji zwiększyłem szerokość przycisku do (ro)zwijania bloczka, gdyż na Firefox jego tekst się niepotrzebnie zawijał. To drobny fix