### PR TITLE
Zmiana domeny API Discorda

### DIFF
--- a/forum/qa-plugin/discord-integration/README.md
+++ b/forum/qa-plugin/discord-integration/README.md
@@ -10,7 +10,7 @@ Clone or download this repository to *qa-plugin* directory in your Q2A.
  
 ## Configuration
 
-Prepare your Discord application. You might create it in [Discord Developer Portal](https://discordapp.com/developers/applications/).
+Prepare your Discord application. You might create it in [Discord Developer Portal](https://discord.com/developers/applications/).
 
 Go to admin panel and `Plugins` tab (*/admin/plugins*). Next, search *Discord integration* and click *settings* link next to the plugin description.
 

--- a/forum/qa-plugin/discord-integration/src/discord-api.php
+++ b/forum/qa-plugin/discord-integration/src/discord-api.php
@@ -2,7 +2,7 @@
 
 class discord_api
 {
-    protected $discord_url = 'https://discordapp.com/api';
+    protected $discord_url = 'https://discord.com/api';
 
     public function get_discord_url()
     {


### PR DESCRIPTION
Zgodnie z rozesłaną przez Discorda informacją

> Discord API Domain Migration
> 
> Last month, we excitedly announced our official move to discord.com. It was a long time in the making, and the work isn't done yet! For now, our API will continue to handle requests made to discordapp.com. On November 7, 2020 we will be dropping support for the discordapp.com domain in favor of discord.com. Please ensure that your libraries, bots, and applications are updated accordingly.
>
> Due to technical constraints, our CDN domain will not be migrated and will remain cdn.discordapp.com for the foreseeable future.

zmieniłem domenę API w naszej integracji Discorda.