### PR TITLE
Poprawka znaków spacji w kodzie kopiowanym przez przycisk

### DIFF
--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -1,5 +1,13 @@
 'use strict';
 
+const fixSpaces = (() => {
+    const NBSP_CHAR_UNICODE_REG_EXP = /\u00a0/g;
+
+    return (text) => {
+        return text.replace(NBSP_CHAR_UNICODE_REG_EXP, ' ');
+    };
+})();
+
 const rawCodeBlocksPreProcessor = () => {
     const BRUSHES_SELECTOR = 'pre[class*="brush:"]';
 
@@ -190,7 +198,7 @@ const postSnippets = () => {
     function processBlockOfCode(block, langData) {
         const codeContent = [
             ...block.querySelectorAll('.code .line')
-        ].reduce((lines, codeLine) => lines + codeLine.textContent + NEW_LINE, '');
+        ].reduce((lines, codeLine) => lines + fixSpaces(codeLine.textContent) + NEW_LINE, '');
         const codeLang = block.parentNode.querySelector('[data-code-lang-alias]').dataset.codeLangAlias;
         const mappedSnippetLang = SNIPPET_LANG_MAP[codeLang];
 
@@ -400,12 +408,7 @@ const codeBlockInteractiveBar = () => {
         class CodeCopy {
             constructor() {
                 this.NEW_LINE = '\r\n';
-                this.NBSP_CHAR_UNICODE_REG_EXP = /\u00a0/g;
                 this.initCopyingMethod();
-            }
-
-            fixSpaces(text) {
-                return text.replace(this.NBSP_CHAR_UNICODE_REG_EXP, ' ');
             }
 
             initCopyingMethod() {
@@ -432,7 +435,7 @@ const codeBlockInteractiveBar = () => {
                 const linesOfCode = [...blockOfCodeParent.querySelector('.code .container').children];
                 const contentToCopy = linesOfCode
                 .reduce((concatenatedCode, { textContent: singleLineOfCode }) => {
-                    return concatenatedCode + this.fixSpaces(singleLineOfCode) + this.NEW_LINE;
+                    return concatenatedCode + fixSpaces(singleLineOfCode) + this.NEW_LINE;
                 }, '');
 
                 return contentToCopy;

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -400,7 +400,12 @@ const codeBlockInteractiveBar = () => {
         class CodeCopy {
             constructor() {
                 this.NEW_LINE = '\r\n';
+                this.NBSP_CHAR_UNICODE_REG_EXP = /\u00a0/g;
                 this.initCopyingMethod();
+            }
+
+            fixSpaces(text) {
+                return text.replace(this.NBSP_CHAR_UNICODE_REG_EXP, ' ');
             }
 
             initCopyingMethod() {
@@ -427,7 +432,7 @@ const codeBlockInteractiveBar = () => {
                 const linesOfCode = [...blockOfCodeParent.querySelector('.code .container').children];
                 const contentToCopy = linesOfCode
                 .reduce((concatenatedCode, { textContent: singleLineOfCode }) => {
-                    return concatenatedCode + singleLineOfCode + this.NEW_LINE;
+                    return concatenatedCode + this.fixSpaces(singleLineOfCode) + this.NEW_LINE;
                 }, '');
 
                 return contentToCopy;


### PR DESCRIPTION
Implementacja kopiowania kodu, podpięta pod przycisk umieszczony w belce bloczków, nie brała pod uwagę, że w HTML'u zdarzają się niełamalne spacje (`&nbsp;`), które po wklejeniu skopiowanego kodu do internetowych edytorów kodu pokroju CodePen/JSFiddle utrudniały jego interpretację.

Poprawka zamienia niełamalne spacje na zwykłe spacje przy kopiowaniu kodu.

Błąd zauważony w [tym poście](https://forum.pasja-informatyki.pl/509206/nie-dziala-mi-w-css-header-oraz-leftbar?show=509221#c509221).

P.S. Przy okazji - jeśli ten PR będzie mergowany, to pewnie znowu pojawi się [problem cache'a przegląrek](https://github.com/CodersCommunity/forum.pasja-informatyki.local/issues/212), który czeka na rozwiązanie w #216.