### PR TITLE
Przeładowanie strony po kliknięciu w nowe powiadomienie dotyczące obecnej strony

### DIFF
--- a/forum/qa-plugin/q2apro-on-site-notifications/script.js
+++ b/forum/qa-plugin/q2apro-on-site-notifications/script.js
@@ -59,23 +59,23 @@ $(document).ready(function(){
 				$('#nfyWrap').fadeOut(500, function(){$(this).remove() });
 			}
 		} else {
-			handleNotificationClickOnSamePage(event.target, event.preventDefault.bind(event));
+			handleNotificationClickWithinWrapper(event.target, event.preventDefault.bind(event));
 		}
 	})
 
-	function handleNotificationClickOnSamePage(clickedElement, preventDefault) {
-		const isAnchorClick = clickedElement.tagName.toLowerCase() === 'a';
-		const anchorURL = new URL(clickedElement.href);
-		const isAnchorHrefSameAsPage = anchorURL.pathname === window.location.pathname;
+	function handleNotificationClickWithinWrapper(clickedElement, preventDefault) {
+		const isAnchorClicked = clickedElement.tagName.toLowerCase() === 'a';
+		const notificationURL = new URL(clickedElement.href);
+		const isNotificationURLEqualsCurrentPage = notificationURL.pathname === window.location.pathname;
 
-		if (isAnchorClick && clickedElement.href && isAnchorHrefSameAsPage) {
-			const isNotificationElementAlreadyOnPage = document.querySelector(anchorURL.hash);
+		if (isAnchorClicked && clickedElement.href && isNotificationURLEqualsCurrentPage) {
+			const isNotificationNew = !document.querySelector(notificationURL.hash);
 
-			if (!isNotificationElementAlreadyOnPage) {
+			if (isNotificationNew) {
 				preventDefault();
 
-				anchorURL.search = new URLSearchParams({ show: anchorURL.hash.slice(1) }).toString();
-				window.location.href = anchorURL;
+				notificationURL.search = new URLSearchParams({ show: notificationURL.hash.slice(1) }).toString();
+				window.location.href = notificationURL;
 			}
 		}
 	}

--- a/forum/qa-plugin/q2apro-on-site-notifications/script.js
+++ b/forum/qa-plugin/q2apro-on-site-notifications/script.js
@@ -9,8 +9,8 @@
 	Plugin License: GPLv3
 	Plugin Minimum Question2Answer Version: 1.5
 	Plugin Update Check URI: https://raw.githubusercontent.com/q2apro/q2apro-on-site-notifications/master/qa-plugin.php
-	
-	This program is free software. You can redistribute and modify it 
+
+	This program is free software. You can redistribute and modify it
 	under the terms of the GNU General Public License.
 
 	This program is distributed in the hope that it will be useful,
@@ -42,7 +42,7 @@ $(document).ready(function(){
 				 success: function(data) {
 					// remove Event-Box if formerly loaded
 					$('#nfyWrap').fadeOut(500, function(){$(this).remove() });
-					// insert ajax-loaded html 
+					// insert ajax-loaded html
 					// $('.qa-nav-user').append(data);
 					$('.osn-new-events-link').after(data);
 					// make yellow notification bubble gray
@@ -51,14 +51,27 @@ $(document).ready(function(){
 			});
 		}
 	});
-	
+
 	// fade out notifybox if visible on stage
-	$(document).click(function(event) { 
+	$(document).click(function(event) {
 		if($(event.target).parents().index($('#nfyWrap')) == -1) {
 			if($('#nfyWrap').is(':visible')) {
 				$('#nfyWrap').fadeOut(500, function(){$(this).remove() });
 			}
-		}        
+		} else {
+			handleNotificationClickOnSamePage(event.target);
+		}
 	})
+
+	function handleNotificationClickOnSamePage(clickedElement) {
+		const isAnchorClick = clickedElement.tagName.toLowerCase() === 'a';
+		const anchorURL = new URL(clickedElement.href);
+		const isAnchorHrefSameAsPage = anchorURL.pathname === window.location.pathname;
+
+		if (isAnchorClick && clickedElement.href && isAnchorHrefSameAsPage) {
+			window.location.assign(anchorURL.hash);
+			window.location.reload();
+		}
+	}
 
 });

--- a/forum/qa-plugin/q2apro-on-site-notifications/script.js
+++ b/forum/qa-plugin/q2apro-on-site-notifications/script.js
@@ -59,18 +59,24 @@ $(document).ready(function(){
 				$('#nfyWrap').fadeOut(500, function(){$(this).remove() });
 			}
 		} else {
-			handleNotificationClickOnSamePage(event.target);
+			handleNotificationClickOnSamePage(event.target, event.preventDefault.bind(event));
 		}
 	})
 
-	function handleNotificationClickOnSamePage(clickedElement) {
+	function handleNotificationClickOnSamePage(clickedElement, preventDefault) {
 		const isAnchorClick = clickedElement.tagName.toLowerCase() === 'a';
 		const anchorURL = new URL(clickedElement.href);
 		const isAnchorHrefSameAsPage = anchorURL.pathname === window.location.pathname;
 
 		if (isAnchorClick && clickedElement.href && isAnchorHrefSameAsPage) {
-			window.location.assign(anchorURL.hash);
-			window.location.reload();
+			const isNotificationElementAlreadyOnPage = document.querySelector(anchorURL.hash);
+
+			if (!isNotificationElementAlreadyOnPage) {
+				preventDefault();
+
+				anchorURL.search = new URLSearchParams({ show: anchorURL.hash.slice(1) }).toString();
+				window.location.href = anchorURL;
+			}
 		}
 	}
 


### PR DESCRIPTION
Poprawka problemu z issue #214 .

Jeśli URL nowego powiadomienia odnosi się do tej samej strony, na której obecnie jest użytkownik, to do URLa powiadomienia zostaje dodany parametr `show=[hash_powiadomienia]`, po czym następuje zmiana aktualnego URLa w przeglądarce na sparametryzowany dla powiadomienia - to powoduje załadowanie od nowa strony z przeniesieniem do posta z nowego powiadomienia.

Wspomniany parametr `show=[hash_powiadomienia]` jest obecny w kilku miejscach na każdej stronie pytania - więc wydaje się być prostym sposobem na naprawę problemu. Można by też na stałe dodać na backendzie ten parametr do URLi dla powiadomień.