### PR TITLE
Poprawka dodawania oznakowania wersji zasobów - wykluczenie zewnętrznych

### DIFF
--- a/forum/qa-include/qa-page.php
+++ b/forum/qa-include/qa-page.php
@@ -388,7 +388,7 @@
                 if (substr($script_src, 0, 4) !== 'http') {
                     $line .= '?v=' . QA_RESOURCE_VERSION;
                 }
-                $line .= '"></script>';
+                $line .= '" defer></script>';
 
                 $script[] = $line;
             }

--- a/forum/qa-include/qa-page.php
+++ b/forum/qa-include/qa-page.php
@@ -384,7 +384,13 @@
         if (isset($qa_content['script_src'])) {
             $uniquesrc = array_unique($qa_content['script_src']); // remove any duplicates
             foreach ($uniquesrc as $script_src) {
-                $script[] = '<script src="' . qa_html($script_src) . '?v=' . QA_RESOURCE_VERSION .'"></script>';
+                $line = '<script src="' . qa_html($script_src);
+                if (substr($script_src, 0, 4) !== 'http') {
+                    $line .= '?v=' . QA_RESOURCE_VERSION;
+                }
+                $line .= '"></script>';
+
+                $script[] = $line;
             }
         }
 

--- a/forum/qa-include/qa-theme-base.php
+++ b/forum/qa-include/qa-theme-base.php
@@ -287,18 +287,14 @@ class qa_html_theme_base
 		}
 	}
 
-	public function head_script()
-	{
-		if (isset($this->content['script'])) {
-		    $deferredScripts = ['ckeditor.js?'];
-
-			foreach ($this->content['script'] as $scriptline) {
-                $scriptline = $this->tryDeferScript($deferredScripts, $scriptline);
-
-				$this->output_raw($scriptline);
+    public function head_script()
+    {
+        if (isset($this->content['script'])) {
+            foreach ($this->content['script'] as $scriptline) {
+                $this->output_raw($scriptline);
             }
-		}
-	}
+        }
+    }
 
 	public function head_css()
 	{
@@ -2381,14 +2377,5 @@ class qa_html_theme_base
 		$this->q_title_list($q_list, 'target="_blank"');
 
 		$this->output('</div>');
-	}
-
-	private function tryDeferScript($deferredScripts, $scriptline) {
-        $isDeferredScript = array_reduce($deferredScripts, function($isFound, $scriptFileName) use ($scriptline) {
-            return $isFound || strpos($scriptline, $scriptFileName);
-        }, false);
-        $optionalDeferAttribute = $isDeferredScript ? 'defer': '';
-
-	    return str_replace('src="', $optionalDeferAttribute .' src="', $scriptline);
 	}
 }


### PR DESCRIPTION
Poprawka do #216 - podczas lokalnych testów nie zostało wyłapane to, że na produkcji mamy np. captche, która jest ładowana przez jedną z tablic do których dodajemy wersję. Przez błędne dodanie dodatkowego parametru wersji captcha przestała działać.

Zrobiłem więc uniwersalny wyjątek, który wyklucza z dodania wersji w tym miejscu wszystkie pliki, które prawdopodobnie będą ładowane z zewnętrznej domeny - czyli gdy ich adres będzie zaczynał się od `http`.