### PR TITLE
Ograniczenie wyświetlania linków na profilu

### DIFF
--- a/forum/qa-include/app/format.php
+++ b/forum/qa-include/app/format.php
@@ -658,7 +658,8 @@
 
         // Message content
         $userPoints = qa_db_select_with_pending(qa_db_user_points_selectspec($message['touserid'], true));
-        $showUrlLinks = ($options['showurllinks'] ?? false) && (qa_is_logged_in() || $userPoints['points'] >= 500);
+        $showUrlLinks = ($options['showurllinks'] ?? false)
+            && (qa_is_logged_in() || $userPoints['points'] >= MIN_POINTS_TO_SHOW_PROFILE_LINKS);
 
         $viewer = qa_load_viewer($message['content'], $message['format']);
         $fields['content'] = $viewer->get_html($message['content'], $message['format'], [

--- a/forum/qa-include/app/format.php
+++ b/forum/qa-include/app/format.php
@@ -657,10 +657,13 @@
 		$fields['tags'] = 'id="m'.qa_html($message['messageid']).'"';
 
         // Message content
+        $userPoints = qa_db_select_with_pending(qa_db_user_points_selectspec($message['touserid'], true));
+        $showUrlLinks = ($options['showurllinks'] ?? false) && (qa_is_logged_in() || $userPoints['points'] >= 500);
+
         $viewer = qa_load_viewer($message['content'], $message['format']);
         $fields['content'] = $viewer->get_html($message['content'], $message['format'], [
             'blockwordspreg' => $options['blockwordspreg'] ?? false,
-            'showurllinks' => $options['showurllinks'] ?? false,
+            'showurllinks' => $showUrlLinks,
             'linksnewwindow' => $options['linksnewwindow'] ?? false,
         ]);
 

--- a/forum/qa-include/app/format.php
+++ b/forum/qa-include/app/format.php
@@ -656,15 +656,13 @@
 		$fields = array('raw' => $message);
 		$fields['tags'] = 'id="m'.qa_html($message['messageid']).'"';
 
-	//	Message content
-
-		$viewer = qa_load_viewer($message['content'], $message['format']);
-
-		$fields['content'] = $viewer->get_html($message['content'], $message['format'], array(
-			'blockwordspreg' => @$options['blockwordspreg'],
-			'showurllinks' => @$options['showurllinks'],
-			'linksnewwindow' => @$options['linksnewwindow'],
-		));
+        // Message content
+        $viewer = qa_load_viewer($message['content'], $message['format']);
+        $fields['content'] = $viewer->get_html($message['content'], $message['format'], [
+            'blockwordspreg' => $options['blockwordspreg'] ?? false,
+            'showurllinks' => $options['showurllinks'] ?? false,
+            'linksnewwindow' => $options['linksnewwindow'] ?? false,
+        ]);
 
 	//	Set ordering of meta elements which can be language-specific
 

--- a/forum/qa-include/app/users.php
+++ b/forum/qa-include/app/users.php
@@ -50,6 +50,7 @@
 
 	@define('QA_FORM_EXPIRY_SECS', 86400); // how many seconds a form is valid for submission
 	@define('QA_FORM_KEY_LENGTH', 32);
+	define('MIN_POINTS_TO_SHOW_PROFILE_LINKS', 500);
 
 
 	if (QA_FINAL_EXTERNAL_USERS) {

--- a/forum/qa-include/pages/user-profile.php
+++ b/forum/qa-include/pages/user-profile.php
@@ -1392,95 +1392,53 @@
 
 
 
-    //    Show other profile fields
-
-
+        // Show other profile fields
 
         $fieldsediting = $fieldseditable && $userediting;
-
-
-
         foreach ($userfields as $userfield) {
-
-            if (($userfield['flags'] & QA_FIELD_FLAGS_LINK_URL) && !$fieldsediting)
-
-                $valuehtml = qa_url_to_html_link(@$userprofile[$userfield['title']], qa_opt('links_in_new_window'));
-
-
-
-            else {
-
-                $value = @$inprofile[$userfield['fieldid']];
-
-                if (!isset($value))
-
-                    $value = @$userprofile[$userfield['title']];
-
-
+            if (($userfield['flags'] & QA_FIELD_FLAGS_LINK_URL) && !$fieldsediting) {
+                $valuehtml = qa_url_to_html_link(
+                    $userprofile[$userfield['title']] ?? null,
+                    qa_opt('links_in_new_window')
+                );
+            } else {
+                $value = $inprofile[$userfield['fieldid']] ?? null;
+                if (!isset($value)) {
+                    $value = $userprofile[$userfield['title']] ?? null;
+                }
 
                 $valuehtml = qa_html($value, (($userfield['flags'] & QA_FIELD_FLAGS_MULTI_LINE) && !$fieldsediting));
-
             }
-
-
 
             $label = trim(qa_user_userfield_label($userfield), ':');
-
-            if (strlen($label))
-
+            if (strlen($label)) {
                 $label .= ':';
-
-
-
-            $notehtml = null;
-
-            if (isset($userfield['permit']) && !$userediting) {
-
-                if ($userfield['permit'] <= QA_PERMIT_ADMINS)
-
-                    $notehtml = qa_lang_html('users/only_shown_admins');
-
-                elseif ($userfield['permit'] <= QA_PERMIT_MODERATORS)
-
-                    $notehtml = qa_lang_html('users/only_shown_moderators');
-
-                elseif ($userfield['permit'] <= QA_PERMIT_EDITORS)
-
-                    $notehtml = qa_lang_html('users/only_shown_editors');
-
-                elseif ($userfield['permit'] <= QA_PERMIT_EXPERTS)
-
-                    $notehtml = qa_lang_html('users/only_shown_experts');
-
-
             }
 
+            $notehtml = null;
+            if (isset($userfield['permit']) && !$userediting) {
+                if ($userfield['permit'] <= QA_PERMIT_ADMINS) {
+                    $notehtml = qa_lang_html('users/only_shown_admins');
+                } elseif ($userfield['permit'] <= QA_PERMIT_MODERATORS) {
+                    $notehtml = qa_lang_html('users/only_shown_moderators');
+                } elseif ($userfield['permit'] <= QA_PERMIT_EDITORS) {
+                    $notehtml = qa_lang_html('users/only_shown_editors');
+                } elseif ($userfield['permit'] <= QA_PERMIT_EXPERTS) {
+                    $notehtml = qa_lang_html('users/only_shown_experts');
+                }
+            }
 
-
-            $qa_content['form_profile']['fields'][$userfield['title']] = array(
-
+            $qa_content['form_profile']['fields'][$userfield['title']] = [
                 'type' => $fieldsediting ? 'text' : 'static',
-
                 'label' => qa_html($label),
-
                 'tags' => 'name="field_'.$userfield['fieldid'].'"',
-
                 'value' => $valuehtml,
-
-                'error' => qa_html(@$errors[$userfield['fieldid']]),
-
+                'error' => qa_html($errors[$userfield['fieldid']] ?? null),
                 'note' => $notehtml,
-
                 'rows' => ($userfield['flags'] & QA_FIELD_FLAGS_MULTI_LINE) ? 8 : null,
-
                 'id' => 'userfield-'.$userfield['fieldid'],
-
-            );
-
+            ];
         }
-
-
-
 
 
     //    Edit form or button, if appropriate

--- a/forum/qa-include/pages/user-profile.php
+++ b/forum/qa-include/pages/user-profile.php
@@ -1395,7 +1395,7 @@
         // Show other profile fields
 
         $fieldsediting = $fieldseditable && $userediting;
-        $canSeeLink = qa_is_logged_in() || $userpoints['points'] >= 500;
+        $canSeeLink = qa_is_logged_in() || $userpoints['points'] >= MIN_POINTS_TO_SHOW_PROFILE_LINKS;
 
         foreach ($userfields as $userfield) {
             if (($userfield['flags'] & QA_FIELD_FLAGS_LINK_URL) && !$fieldsediting && $canSeeLink) {

--- a/forum/qa-include/pages/user-profile.php
+++ b/forum/qa-include/pages/user-profile.php
@@ -1395,8 +1395,10 @@
         // Show other profile fields
 
         $fieldsediting = $fieldseditable && $userediting;
+        $canSeeLink = qa_is_logged_in() || $userpoints['points'] >= 500;
+
         foreach ($userfields as $userfield) {
-            if (($userfield['flags'] & QA_FIELD_FLAGS_LINK_URL) && !$fieldsediting) {
+            if (($userfield['flags'] & QA_FIELD_FLAGS_LINK_URL) && !$fieldsediting && $canSeeLink) {
                 $valuehtml = qa_url_to_html_link(
                     $userprofile[$userfield['title']] ?? null,
                     qa_opt('links_in_new_window')


### PR DESCRIPTION
Przygotowałem propozycję rozwiązania problemu z #226 

Osoby niezalogowane na profilach poniżej 500 punktów zobaczą linki jako goły tekst, nie jako <a href... w które można kliknąć. Pozostali będą mieli normalne linki, w tym również osoby zalogowane przeglądające profile, które mają mniej niż 500 punktów. Zmiana dotyczy linków we wszystkich polach profilu (u nas obecnie jest tylko jedno takie) oraz ściany.
