### PR TITLE
Zmiana domyślnie wybranej podkategorii na brak wyboru

### DIFF
--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -233,8 +233,7 @@ function qa_category_select(idprefix, startpath)
 										newelem.name=newelem.id=idprefix+'_'+(l+1);
 										newelem.options.length=0;
 
-										if (l ? qa_cat_allownosub : qa_cat_allownone)
-											newelem.options[0]=new Option(l ? '' : elem.options[0].text, '', true, true);
+										newelem.options[0]=new Option('', '', true, true);
 
 										for (var i=2; i<lines.length; i++) {
 											var parts=lines[i].split('/');

--- a/forum/qa-include/lang/qa-lang-question.php
+++ b/forum/qa-include/lang/qa-lang-question.php
@@ -62,6 +62,7 @@
 		'category_ask_not_allowed' => 'You do not have permission to ask questions in this category',
 		'category_js_note' => 'To select any category, please enable Javascript in your web browser.',
 		'category_required' => 'Please choose a category',
+		'subcategory_required' => 'Please choose a subcategory',
 		'claim_a_popup' => 'Assign this answer to your user account',
 		'claim_button' => 'I wrote this',
 		'claim_c_popup' => 'Assign this comment to your user account',

--- a/forum/qa-include/pages/ask.php
+++ b/forum/qa-include/pages/ask.php
@@ -131,13 +131,13 @@
             $subcategories = array_filter($categories, function ($category) use ($mainCategory) {
                 return $category['parentid'] === $mainCategory;
             });
-            $subcategories = array_column($subcategories, 'categoryid');
+            $subcategoriesIds = array_column($subcategories, 'categoryid');
 
             if ($categoriesEnabled && !qa_opt('allow_no_category') && !isset($in['categoryid'])) {
                 $errors['categoryid'] = qa_lang_html('question/category_required');
             } elseif (qa_user_permit_error('permit_post_q', null, $userlevel)) {
                 $errors['categoryid'] = qa_lang_html('question/category_ask_not_allowed');
-            } elseif (!$noSubcategory && !empty($subcategories) && !in_array($in['categoryid'], $subcategories)) {
+            } elseif (!$noSubcategory && !empty($subcategoriesIds) && !in_array($in['categoryid'], $subcategoriesIds)) {
                 $errors['categoryid'] = qa_lang_html('question/subcategory_required');
             }
 

--- a/forum/qa-lang/pl/qa-lang-options.php
+++ b/forum/qa-lang/pl/qa-lang-options.php
@@ -26,8 +26,8 @@
 		'allow_login_email_only' => 'Dozwolone logowanie tylko przez adres email (nie nazwę użytkownika):',
 		'allow_multi_answers' => 'Więcej niż jedna odpowiedź na użytkownika:',
 		'allow_no_category' => 'Pozwól na pytania bez kategorii',
-		'allow_no_sub_category' => 'Pozwój na pytania w kategorii ale bez podkategorii',
-		'allow_private_messages' => 'Pozwój na wysyłanie wiadomości między użytkownikami:',
+		'allow_no_sub_category' => 'Pozwól na pytania w kategorii ale bez podkategorii',
+		'allow_private_messages' => 'Pozwól na wysyłanie wiadomości między użytkownikami:',
 		'allow_self_answer' => 'Pozwól użytkownikom na odpowiadanie na ich własne pytania:',
 		'allow_view_q_bots' => 'Pozwól wyszukiwarkom na dostęp do strony z pytaniem',
 		'avatar_allow_gravatar' => 'Pozwól na ^1Gravatary^2:',
@@ -285,7 +285,7 @@
 		'show_register_terms' => "Zasady i Warunki checkbox na formie rejestracyjnej - dozwolone tagi HTML:",
 		'site_text_direction' => "Kierunek znaków na stronie:",
 	);
-	
+
 
 /*
 	Omit PHP closing tag to help avoid accidental output

--- a/forum/qa-lang/pl/qa-lang-question.php
+++ b/forum/qa-lang/pl/qa-lang-question.php
@@ -54,6 +54,7 @@
 		'c_your_waiting_approval' => 'Twój komentarz został przekazany do moderacji.',
 		'category_js_note' => 'Aby wybrać kategorię, włącz JavaScript w swojej przeglądarce.',
 		'category_required' => 'Wybierz kategorię',
+		'subcategory_required' => 'Wybierz podkategorię',
 		'claim_button' => 'Ja to napisałem/napisałam',
 		'clear_flags_button' => 'wycofaj zgłoszenia',
 		'clear_flags_popup' => 'Wycofaj zgłoszenia wszystkich użytkowników',


### PR DESCRIPTION
Fixes #213 - od teraz podkategoria zawsze jest domyślnie pusta oraz dodana jest walidacja jej wyboru.

Działa to z mechanizmem opcji "Pozwól na pytania bez kategorii" i "Pozwól na pytania w kategorii ale bez podkategorii" zarządzanych z panelu - nie używamy ich co prawda (tzn. u nas są odznaczone), ale aby w razie potrzeby można było skorzystać, uwzględniłem tu ich obsługę.