### PR TITLE
Wysyłanie do serwera Node wybranych eventów

### DIFF
--- a/forum/qa-plugin/async-lists/async-lists-event.php
+++ b/forum/qa-plugin/async-lists/async-lists-event.php
@@ -8,16 +8,41 @@ class async_lists_event
             return;
         }
 
-        $this->send_to_websocket($event);
+        switch ($event) {
+            case 'q_post':
+            case 'q_edit':
+            case 'q_hide':
+            case 'q_reshow':
+            case 'q_close':
+            case 'q_reopen':
+            case 'q_move':
+                $this->send_to_websocket($event, ['question_id' => (int)$params['postid']]);
+                break;
+            case 'a_post':
+            case 'a_edit':
+            case 'a_hide':
+            case 'a_reshow':
+            case 'a_select':
+            case 'a_unselect':
+                $this->send_to_websocket($event, ['question_id' => (int)$params['parentid']]);
+                break;
+            case 'c_post':
+            case 'c_edit':
+            case 'c_hide':
+            case 'c_reshow':
+            case 'a_to_c':
+                $this->send_to_websocket($event, ['question_id' => (int)$params['questionid']]);
+                break;
+        }
     }
 
-    private function send_to_websocket($action)
+    private function send_to_websocket($action, $data = [])
     {
         $options = [
             'http' => [
                 'header' => "Content-Type: application/json\r\n" . "token: " . QA_WS_TOKEN . "\r\n",
                 'method' => 'POST',
-                'content' => json_encode(['action' => $action], JSON_UNESCAPED_UNICODE)
+                'content' => json_encode(['action' => $action, 'data' => $data], JSON_UNESCAPED_UNICODE)
             ]
         ];
 


### PR DESCRIPTION
Zgodnie z rozmową ze @ScriptyChris na Discordzie, do serwera w Node potrzebujemy wysyłać tylko określone eventy wraz z parametrami. Na ten moment zostało ustalone:
> q2a ma wysłać do node eventy: 

- q_post 
- a_post 
- c_post 
- q_edit 
- a_edit 
- c_edit 
- q_hide 
- a_hide 
- c_hide 
- q_reshow 
- a_reshow 
- c_reshow 
- q_close 
- q_reopen 
- a_select 
- a_unselect 
- q_move 
- a_to_c

każdy wraz z question id którego dotyczy

To wprowadza ten PR.