### PR TITLE
Naprawa komunikatu o niedostępności posta podczas dodawania odpowiedzi/komentarza

### DIFF
--- a/forum/qa-content/qa-question.js
+++ b/forum/qa-content/qa-question.js
@@ -103,16 +103,10 @@ function qa_submit_answer(questionid, elem)
 				qa_reveal(answerItem, 'answer', () => tryHighlightAndDecorateCodeBlocks(answerItem));
 			} else if (lines[0]=='0') {
 				const [, answerRefuseReason ] = lines;
-
-				if (answerRefuseReason === 'ALREADY_CLOSED' || answerRefuseReason === 'UNAVAILABLE') {
-					window.handleRefusedPost({
-						postType: 'answer',
-						postRefuseReason: answerRefuseReason,
-						submitButton: elem
-					});
-				} else {
-					document.forms['a_form'].submit();
-				}
+				window.handleRefusedPost({
+					postRefuseReason: answerRefuseReason,
+					submitButton: elem
+				});
 			} else {
 				qa_ajax_error();
 			}
@@ -141,18 +135,11 @@ function qa_submit_comment(questionid, parentid, elem) {
 				.then(() => tryHighlightAndDecorateCodeBlocks(updatedCommentsList));
 		} else if (lines[0] == '0') {
 			const [, commentRefuseReason] = lines;
-
-			if (commentRefuseReason === 'UNAVAILABLE') {
-				window.handleRefusedPost({
-					postType: 'comment',
-					postRefuseReason: commentRefuseReason,
-					parentId: parentid,
-					parentPostIsQuestion: questionid === parentid,
-					submitButton: elem
-				});
-			} else {
-				document.forms['c_form_' + parentid].submit();
-			}
+			window.handleRefusedPost({
+				postRefuseReason: commentRefuseReason,
+				parentId: parentid,
+				submitButton: elem
+			});
 		} else {
 			qa_ajax_error();
 		}
@@ -343,7 +330,7 @@ function tryHighlightAndDecorateCodeBlocks(target, targetId, includeCommentsList
 	}
 }
 
-function handleRefusedPost({ submitButton, postRefuseReason, postType, parentId, parentPostIsQuestion }) {
+function handleRefusedPost({ submitButton, postRefuseReason, parentId }) {
 	submitButton.disabled = true;
 
 	hideEmailNotificationOption();
@@ -352,7 +339,7 @@ function handleRefusedPost({ submitButton, postRefuseReason, postType, parentId,
 
 	function showSubmissionError() {
 		const postSubmissionError = document.createElement('div');
-		postSubmissionError.innerHTML = getSubmissionErrorContent();
+		postSubmissionError.innerHTML = postRefuseReason || 'Wystąpił problem - nie udało się dodać posta.';
 		postSubmissionError.classList.add('post-submission-alert');
 
 		submitButton.parentNode.insertBefore(postSubmissionError, submitButton);
@@ -362,25 +349,5 @@ function handleRefusedPost({ submitButton, postRefuseReason, postType, parentId,
 		const formNotifyElementName = parentId ? `c${ parentId }_notify` : 'a_notify';
 		const emailNotificationOption = submitButton.form.elements[formNotifyElementName].parentNode.parentNode;
 		emailNotificationOption.remove();
-	}
-
-	function getSubmissionErrorContent() {
-		const postErrorDescription = postType === 'comment' ?
-			'Nie można dodać komentarza.' :
-			'Nie można dodać odpowiedzi.';
-		const submissionErrorContent = {
-			ALREADY_CLOSED: 'Nie można dodać odpowiedzi, ponieważ pytanie zostało zamknięte.<br>Jeśli chcesz, to dodaj swój post w formie komentarza.',
-			UNAVAILABLE: `${ postErrorDescription } ${ getPostRelationDescription() }`
-		};
-
-		return submissionErrorContent[postRefuseReason];
-	}
-
-	function getPostRelationDescription() {
-		if (postType === 'comment') {
-			return parentPostIsQuestion ? 'Pytanie nie jest już dostępne.' : 'Odpowiedź nie jest już dostępna.';
-		} else {
-			return 'Temat nie jest już dostępny.';
-		}
 	}
 }

--- a/forum/qa-content/qa-question.js
+++ b/forum/qa-content/qa-question.js
@@ -339,7 +339,7 @@ function handleRefusedPost({ submitButton, postRefuseReason, parentId }) {
 
 	function showSubmissionError() {
 		const postSubmissionError = document.createElement('div');
-		postSubmissionError.innerHTML = postRefuseReason || 'Wystąpił problem - nie udało się dodać posta.';
+		postSubmissionError.textContent = postRefuseReason || 'Wystąpił problem - nie udało się dodać posta.';
 		postSubmissionError.classList.add('post-submission-alert');
 
 		submitButton.parentNode.insertBefore(postSubmissionError, submitButton);

--- a/forum/qa-include/lang/qa-lang-question.php
+++ b/forum/qa-include/lang/qa-lang-question.php
@@ -173,6 +173,9 @@
 		'your_answer_title' => 'Your answer',
 		'your_comment_a' => 'Your comment on this answer:',
 		'your_comment_q' => 'Your comment on this question:',
+		'question_closed' => 'You can\'t add answer, because the question has been closed.',
+		'question_hidden' => 'You can\'t add answer, because the question has been hidden.',
+		'question_answer_hidden' => 'You can\'t add comment, because the post has been hidden.',
 	);
 
 

--- a/forum/qa-lang/pl/qa-lang-question.php
+++ b/forum/qa-lang/pl/qa-lang-question.php
@@ -173,6 +173,10 @@
 		'reshow_a_popup' => "Wyświetl tą odpowiedź",
 		'reshow_c_popup' => "Wyświetl ten komentarz",
 		'reshow_q_popup' => "Wyświetl to pytanie",
+
+		'question_closed' => "Nie można dodać odpowiedzi, ponieważ pytanie zostało zamknięte.",
+		'question_hidden' => "Nie można dodać odpowiedzi, ponieważ pytanie zostało ukryte.",
+		'question_answer_hidden' => "Nie można dodać komentarza, ponieważ post został ukryty.",
 	);
 
 /*


### PR DESCRIPTION
Przygotowałem propozycję części backendowej do poprawy problemu #249. W obecnej wersji zrobiłem tak, że usunąłem frazy `ALREADY_CLOSED`/`UNAVAILABLE` z response. Teraz response na Ajaxa dodającego odpowiedź lub komentarz gdy wystąpił błąd wygląda tak:
> QA_AJAX_RESPONSE
> 0
> treść błędu

Front mógłby sprawdzić czy w drugiej linii występuje 0, jeśli tak to odczytać kolejną linię i jeśli coś tam jest to wyświetlić to jako błąd. Gdy nie ma 3 linii to ewentualnie na wszelki wypadek można wyświetlić jakiś ogólny błąd (wydaje mi się, że taka sytuacja może się zdarzyć, gdy np. pytanie zostanie całkowicie usunięte, a nie ukryte) albo po prostu wtedy pozwolić odświeżyć stronę, jak było wcześniej. Jeśli potrzebny jest dodatkowo jakiś typ błędu, aby to dobrze wyświetlić na froncie, to trzeba ustalić jaki i można dodać. Ta funkcjonalność już była zmieniana wcześniej bezpośrednio na core i gdzieś na froncie i na backendzie nie jako plugin, więc tak pociągnąłem dalej - jak nam bardzo zależy to można spróbować czy da się przenieść to na plugin.

Fixes #249 