### PR TITLE
Dodanie RWD dla listy historii zmian nicka

### DIFF
--- a/forum/qa-plugin/q2a-change-username-limit/css/style.css
+++ b/forum/qa-plugin/q2a-change-username-limit/css/style.css
@@ -62,4 +62,60 @@
 
 .q2a-change-username-history-list__info i {
     font-size: 1.5em;
+    color: var(--primary-color);
+}
+
+@media screen and (max-width: 460px) {
+    .q2a-change-username-history-list__entry {
+        flex-direction: column;
+    }
+
+    .q2a-change-username-history-list__datetime {
+        flex-direction: row;
+        justify-content: space-around;
+        border-bottom: 1px dashed var(--primary-color);
+        padding-bottom: 10px;
+    }
+
+    .q2a-change-username-history-list__datetime time {
+        flex-basis: 50%;
+        text-align: center;
+    }
+
+    .q2a-change-username-history-list__datetime :nth-child(2) {
+        margin-top: 6.2px;
+    }
+
+    .q2a-change-username-history-list__info {
+        min-height: 50px;
+        text-align: center;
+    }
+
+    .q2a-change-username-history-list__info span {
+        flex-basis: 45%;
+        padding: 5px;
+    }
+
+    .q2a-change-username-history-list__info i {
+        flex-basis: 10%;
+    }
+}
+
+@media screen and (max-width: 375px) {
+    .q2a-change-username-history-list__datetime {
+        flex-direction: column;
+        align-items: center;
+        font-size: 0.75rem;
+        margin-bottom: 5px;
+    }
+
+    .q2a-change-username-history-list__info {
+        flex-direction: column;
+    }
+
+    .q2a-change-username-history-list__info i {
+        margin: -10px 0;
+        text-align: center;
+        transform: rotate(90deg) translateY(-5px);
+    }
 }

--- a/forum/qa-plugin/q2a-change-username-limit/css/style.css
+++ b/forum/qa-plugin/q2a-change-username-limit/css/style.css
@@ -70,6 +70,10 @@
         flex-direction: column;
     }
 
+    .q2a-change-username-history-list__datetime :first-child {
+        font-size: 1.4em;
+    }
+
     .q2a-change-username-history-list__datetime {
         flex-direction: row;
         justify-content: space-around;
@@ -102,6 +106,7 @@
 }
 
 @media screen and (max-width: 375px) {
+
     .q2a-change-username-history-list__datetime {
         flex-direction: column;
         align-items: center;


### PR DESCRIPTION
Ostatnio dodany ficzer historii zmian nicka (#244) nie był responsywny - szczególnie poniżej szerokości 400px.
Poprawki obejmują:

- dodanie dwóch breakpointów `@media`: `460px` i `375px`,
- zmiana koloru strzałki prezentującej zmianę nicka oraz (dla najmniejszej rozdzielczości) obrócenie jej o 90 stopni w dół,
- dodanie niebieskiego przerywanego bordera.

**Przed:**

![image](https://user-images.githubusercontent.com/18393526/115958140-70747800-a506-11eb-937c-59f61c16c7e9.png)

**Po:**

![image](https://user-images.githubusercontent.com/18393526/115958172-97cb4500-a506-11eb-8c89-ec1ce031bdd6.png)
![image](https://user-images.githubusercontent.com/18393526/115958185-a6196100-a506-11eb-8a5d-970d1f68e9ce.png)
