### PR TITLE
Dodanie statusów http do niektórych odpowiedzi z błędami

### DIFF
--- a/forum/qa-include/Q2A/Response.php
+++ b/forum/qa-include/Q2A/Response.php
@@ -1,0 +1,11 @@
+<?php
+
+class Q2A_Response
+{
+    public const STATUS_OK = 200;
+
+    public const STATUS_UNAUTHORIZED = 401;
+    public const STATUS_FORBIDDEN = 403;
+    public const STATUS_NOT_FOUND = 404;
+    public const STATUS_TOO_MANY_REQUESTS = 429;
+}

--- a/forum/qa-include/app/admin.php
+++ b/forum/qa-include/app/admin.php
@@ -39,6 +39,7 @@
 
 			$qa_content['title']=qa_lang_html('admin/admin_title');
 			$qa_content['error']=qa_insert_login_links(qa_lang_html('admin/not_logged_in'), qa_request());
+			$qa_content['http_status']=401;
 
 			return false;
 
@@ -47,6 +48,7 @@
 
 			$qa_content['title']=qa_lang_html('admin/admin_title');
 			$qa_content['error']=qa_lang_html('admin/no_privileges');
+			$qa_content['http_status']=403;
 
 			return false;
 		}

--- a/forum/qa-include/app/admin.php
+++ b/forum/qa-include/app/admin.php
@@ -39,7 +39,7 @@
 
 			$qa_content['title']=qa_lang_html('admin/admin_title');
 			$qa_content['error']=qa_insert_login_links(qa_lang_html('admin/not_logged_in'), qa_request());
-			$qa_content['http_status']=401;
+			$qa_content['http_status']=Q2A_Response::STATUS_UNAUTHORIZED;
 
 			return false;
 
@@ -48,7 +48,7 @@
 
 			$qa_content['title']=qa_lang_html('admin/admin_title');
 			$qa_content['error']=qa_lang_html('admin/no_privileges');
-			$qa_content['http_status']=403;
+			$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 
 			return false;
 		}

--- a/forum/qa-include/pages/account.php
+++ b/forum/qa-include/pages/account.php
@@ -326,6 +326,7 @@
 	if ($isblocked) {
 		unset($qa_content['form_profile']['buttons']['save']);
 		$qa_content['error']=qa_lang_html('users/no_permission');
+		$qa_content['http_status']=403;
 	}
 
 //	Avatar upload stuff

--- a/forum/qa-include/pages/account.php
+++ b/forum/qa-include/pages/account.php
@@ -326,7 +326,7 @@
 	if ($isblocked) {
 		unset($qa_content['form_profile']['buttons']['save']);
 		$qa_content['error']=qa_lang_html('users/no_permission');
-		$qa_content['http_status']=403;
+		$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 	}
 
 //	Avatar upload stuff

--- a/forum/qa-include/pages/admin/admin-approve.php
+++ b/forum/qa-include/pages/admin/admin-approve.php
@@ -48,6 +48,7 @@
 	if (qa_get_logged_in_level()<QA_USER_LEVEL_MODERATOR) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
+		$qa_content['http_status']=403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/admin/admin-approve.php
+++ b/forum/qa-include/pages/admin/admin-approve.php
@@ -48,7 +48,7 @@
 	if (qa_get_logged_in_level()<QA_USER_LEVEL_MODERATOR) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
-		$qa_content['http_status']=403;
+		$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/admin/admin-flagged.php
+++ b/forum/qa-include/pages/admin/admin-flagged.php
@@ -44,6 +44,7 @@
 	if (qa_user_maximum_permit_error('permit_hide_show')) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
+		$qa_content['http_status']=403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/admin/admin-flagged.php
+++ b/forum/qa-include/pages/admin/admin-flagged.php
@@ -44,7 +44,7 @@
 	if (qa_user_maximum_permit_error('permit_hide_show')) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
-		$qa_content['http_status']=403;
+		$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/admin/admin-hidden.php
+++ b/forum/qa-include/pages/admin/admin-hidden.php
@@ -47,6 +47,7 @@
 	if (qa_user_maximum_permit_error('permit_hide_show') && qa_user_maximum_permit_error('permit_delete_hidden')) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
+		$qa_content['http_status']=403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/admin/admin-hidden.php
+++ b/forum/qa-include/pages/admin/admin-hidden.php
@@ -47,7 +47,7 @@
 	if (qa_user_maximum_permit_error('permit_hide_show') && qa_user_maximum_permit_error('permit_delete_hidden')) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
-		$qa_content['http_status']=403;
+		$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/admin/admin-moderate.php
+++ b/forum/qa-include/pages/admin/admin-moderate.php
@@ -46,7 +46,7 @@
 	if (qa_user_maximum_permit_error('permit_moderate')) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
-		$qa_content['http_status']=403;
+		$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/admin/admin-moderate.php
+++ b/forum/qa-include/pages/admin/admin-moderate.php
@@ -46,6 +46,7 @@
 	if (qa_user_maximum_permit_error('permit_moderate')) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
+		$qa_content['http_status']=403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/ask.php
+++ b/forum/qa-include/pages/ask.php
@@ -65,27 +65,27 @@
 		switch ($permiterror) {
 			case 'login':
 				$qa_content['error']=qa_insert_login_links(qa_lang_html('question/ask_must_login'), qa_request(), isset($followpostid) ? array('follow' => $followpostid) : null);
-				$qa_content['http_status']=401;
+				$qa_content['http_status']=Q2A_Response::STATUS_UNAUTHORIZED;
 				break;
 
 			case 'confirm':
 				$qa_content['error']=qa_insert_login_links(qa_lang_html('question/ask_must_confirm'), qa_request(), isset($followpostid) ? array('follow' => $followpostid) : null);
-				$qa_content['http_status']=403;
+				$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 				break;
 
 			case 'limit':
 				$qa_content['error']=qa_lang_html('question/ask_limit');
-				$qa_content['http_status']=429;
+				$qa_content['http_status']=Q2A_Response::STATUS_TOO_MANY_REQUESTS;
 				break;
 
 			case 'approve':
 				$qa_content['error']=qa_lang_html('question/ask_must_be_approved');
-				$qa_content['http_status']=403;
+				$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 				break;
 
 			default:
 				$qa_content['error']=qa_lang_html('users/no_permission');
-				$qa_content['http_status']=403;
+				$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 				break;
 		}
 

--- a/forum/qa-include/pages/ask.php
+++ b/forum/qa-include/pages/ask.php
@@ -65,22 +65,27 @@
 		switch ($permiterror) {
 			case 'login':
 				$qa_content['error']=qa_insert_login_links(qa_lang_html('question/ask_must_login'), qa_request(), isset($followpostid) ? array('follow' => $followpostid) : null);
+				$qa_content['http_status']=401;
 				break;
 
 			case 'confirm':
 				$qa_content['error']=qa_insert_login_links(qa_lang_html('question/ask_must_confirm'), qa_request(), isset($followpostid) ? array('follow' => $followpostid) : null);
+				$qa_content['http_status']=403;
 				break;
 
 			case 'limit':
 				$qa_content['error']=qa_lang_html('question/ask_limit');
+				$qa_content['http_status']=429;
 				break;
 
 			case 'approve':
 				$qa_content['error']=qa_lang_html('question/ask_must_be_approved');
+				$qa_content['http_status']=403;
 				break;
 
 			default:
 				$qa_content['error']=qa_lang_html('users/no_permission');
+				$qa_content['http_status']=403;
 				break;
 		}
 

--- a/forum/qa-include/pages/default.php
+++ b/forum/qa-include/pages/default.php
@@ -81,6 +81,7 @@
 
 		} else
 			$qa_content['error']=qa_lang_html('users/no_permission');
+			$qa_content['http_status']=403;
 
 		return $qa_content;
 	}

--- a/forum/qa-include/pages/default.php
+++ b/forum/qa-include/pages/default.php
@@ -81,7 +81,7 @@
 
 		} else {
 			$qa_content['error'] = qa_lang_html('users/no_permission');
-			$qa_content['http_status'] = 403;
+			$qa_content['http_status'] = Q2A_Response::STATUS_FORBIDDEN;
 		}
 
 		return $qa_content;

--- a/forum/qa-include/pages/default.php
+++ b/forum/qa-include/pages/default.php
@@ -79,9 +79,10 @@
 				);
 			}
 
-		} else
-			$qa_content['error']=qa_lang_html('users/no_permission');
-			$qa_content['http_status']=403;
+		} else {
+			$qa_content['error'] = qa_lang_html('users/no_permission');
+			$qa_content['http_status'] = 403;
+		}
 
 		return $qa_content;
 	}

--- a/forum/qa-include/pages/feedback.php
+++ b/forum/qa-include/pages/feedback.php
@@ -50,6 +50,7 @@
 	if (qa_user_permit_error()) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
+		$qa_content['http_status']=403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/feedback.php
+++ b/forum/qa-include/pages/feedback.php
@@ -50,7 +50,7 @@
 	if (qa_user_permit_error()) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
-		$qa_content['http_status']=403;
+		$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 
@@ -179,7 +179,7 @@
 	}
 
 	$qa_content['script_rel'][] = 'qa-content/qa-forms-protection.js';
-	
+
 	return $qa_content;
 
 

--- a/forum/qa-include/pages/ip.php
+++ b/forum/qa-include/pages/ip.php
@@ -58,7 +58,7 @@
 	if (qa_user_maximum_permit_error('permit_anon_view_ips')) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
-		$qa_content['http_status']=403;
+		$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/ip.php
+++ b/forum/qa-include/pages/ip.php
@@ -58,6 +58,7 @@
 	if (qa_user_maximum_permit_error('permit_anon_view_ips')) {
 		$qa_content=qa_content_prepare();
 		$qa_content['error']=qa_lang_html('users/no_permission');
+		$qa_content['http_status']=403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/message.php
+++ b/forum/qa-include/pages/message.php
@@ -47,14 +47,14 @@
 
 	if (!isset($loginuserid)) {
 		$qa_content['error'] = qa_insert_login_links(qa_lang_html('misc/message_must_login'), qa_request());
-		$qa_content['http_status'] = 401;
+		$qa_content['http_status'] = Q2A_Response::STATUS_UNAUTHORIZED;
 		return $qa_content;
 	}
 
 	if ($handle === $fromhandle) {
 		// prevent users sending messages to themselves
 		$qa_content['error'] = qa_lang_html('users/no_permission');
-		$qa_content['http_status'] = 403;
+		$qa_content['http_status'] = Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 
@@ -74,7 +74,7 @@
             $userLevel = qa_get_logged_in_level();
             if($userLevel < QA_USER_LEVEL_EDITOR) {
                 return include QA_INCLUDE_DIR.'qa-page-not-found.php';
-            }	
+            }
 
         }
 
@@ -250,7 +250,7 @@
 	$qa_content['raw']['account'] = $toaccount; // for plugin layers to access
 
 	$qa_content['script_rel'][] = 'qa-content/qa-forms-protection.js';
-	
+
 	return $qa_content;
 
 

--- a/forum/qa-include/pages/message.php
+++ b/forum/qa-include/pages/message.php
@@ -47,12 +47,14 @@
 
 	if (!isset($loginuserid)) {
 		$qa_content['error'] = qa_insert_login_links(qa_lang_html('misc/message_must_login'), qa_request());
+		$qa_content['http_status'] = 401;
 		return $qa_content;
 	}
 
 	if ($handle === $fromhandle) {
 		// prevent users sending messages to themselves
 		$qa_content['error'] = qa_lang_html('users/no_permission');
+		$qa_content['http_status'] = 403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/messages.php
+++ b/forum/qa-include/pages/messages.php
@@ -50,7 +50,7 @@
 	if (!isset($loginUserId)) {
 		$qa_content = qa_content_prepare();
 		$qa_content['error'] = qa_insert_login_links(qa_lang_html('misc/message_must_login'), qa_request());
-		$qa_content['http_status'] = 401;
+		$qa_content['http_status'] = Q2A_Response::STATUS_UNAUTHORIZED;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/messages.php
+++ b/forum/qa-include/pages/messages.php
@@ -50,6 +50,7 @@
 	if (!isset($loginUserId)) {
 		$qa_content = qa_content_prepare();
 		$qa_content['error'] = qa_insert_login_links(qa_lang_html('misc/message_must_login'), qa_request());
+		$qa_content['http_status'] = 401;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/question.php
+++ b/forum/qa-include/pages/question.php
@@ -95,7 +95,7 @@
 			$qa_content['error']=qa_lang_html('question/q_hidden_other');
 
 		$qa_content['suggest_next']=qa_html_suggest_qs_tags(qa_using_tags());
-		$qa_content['http_status']=404;
+		$qa_content['http_status']=Q2A_Response::STATUS_NOT_FOUND;
 
 		return $qa_content;
 	}
@@ -109,22 +109,22 @@
 		switch ($permiterror) {
 			case 'login':
 				$qa_content['error']=qa_insert_login_links(qa_lang_html('main/view_q_must_login'), $topage);
-				$qa_content['http_status']=401;
+				$qa_content['http_status']=Q2A_Response::STATUS_UNAUTHORIZED;
 				break;
 
 			case 'confirm':
 				$qa_content['error']=qa_insert_login_links(qa_lang_html('main/view_q_must_confirm'), $topage);
-				$qa_content['http_status']=403;
+				$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 				break;
 
 			case 'approve':
 				$qa_content['error']=qa_lang_html('main/view_q_must_be_approved');
-				$qa_content['http_status']=403;
+				$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 				break;
 
 			default:
 				$qa_content['error']=qa_lang_html('users/no_permission');
-				$qa_content['http_status']=403;
+				$qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 				break;
 		}
 

--- a/forum/qa-include/pages/question.php
+++ b/forum/qa-include/pages/question.php
@@ -95,6 +95,7 @@
 			$qa_content['error']=qa_lang_html('question/q_hidden_other');
 
 		$qa_content['suggest_next']=qa_html_suggest_qs_tags(qa_using_tags());
+		$qa_content['http_status']=404;
 
 		return $qa_content;
 	}
@@ -108,18 +109,22 @@
 		switch ($permiterror) {
 			case 'login':
 				$qa_content['error']=qa_insert_login_links(qa_lang_html('main/view_q_must_login'), $topage);
+				$qa_content['http_status']=401;
 				break;
 
 			case 'confirm':
 				$qa_content['error']=qa_insert_login_links(qa_lang_html('main/view_q_must_confirm'), $topage);
+				$qa_content['http_status']=403;
 				break;
 
 			case 'approve':
 				$qa_content['error']=qa_lang_html('main/view_q_must_be_approved');
+				$qa_content['http_status']=403;
 				break;
 
 			default:
 				$qa_content['error']=qa_lang_html('users/no_permission');
+				$qa_content['http_status']=403;
 				break;
 		}
 

--- a/forum/qa-include/pages/register.php
+++ b/forum/qa-include/pages/register.php
@@ -63,6 +63,7 @@
 	if (qa_user_permit_error()) {
 		$qa_content = qa_content_prepare();
 		$qa_content['error'] = qa_lang_html('users/no_permission');
+		$qa_content['http_status'] = 403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/register.php
+++ b/forum/qa-include/pages/register.php
@@ -63,7 +63,7 @@
 	if (qa_user_permit_error()) {
 		$qa_content = qa_content_prepare();
 		$qa_content['error'] = qa_lang_html('users/no_permission');
-		$qa_content['http_status'] = 403;
+		$qa_content['http_status'] = Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/users-blocked.php
+++ b/forum/qa-include/pages/users-blocked.php
@@ -53,6 +53,7 @@
 	if (qa_get_logged_in_level() < QA_USER_LEVEL_MODERATOR) {
 		$qa_content = qa_content_prepare();
 		$qa_content['error'] = qa_lang_html('users/no_permission');
+		$qa_content['http_status'] = 403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/users-blocked.php
+++ b/forum/qa-include/pages/users-blocked.php
@@ -53,7 +53,7 @@
 	if (qa_get_logged_in_level() < QA_USER_LEVEL_MODERATOR) {
 		$qa_content = qa_content_prepare();
 		$qa_content['error'] = qa_lang_html('users/no_permission');
-		$qa_content['http_status'] = 403;
+		$qa_content['http_status'] = Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/users-special.php
+++ b/forum/qa-include/pages/users-special.php
@@ -46,6 +46,7 @@
 	if (qa_get_logged_in_level() < QA_USER_LEVEL_MODERATOR) {
 		$qa_content = qa_content_prepare();
 		$qa_content['error'] = qa_lang_html('users/no_permission');
+		$qa_content['http_status'] = 403;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/pages/users-special.php
+++ b/forum/qa-include/pages/users-special.php
@@ -46,7 +46,7 @@
 	if (qa_get_logged_in_level() < QA_USER_LEVEL_MODERATOR) {
 		$qa_content = qa_content_prepare();
 		$qa_content['error'] = qa_lang_html('users/no_permission');
-		$qa_content['http_status'] = 403;
+		$qa_content['http_status'] = Q2A_Response::STATUS_FORBIDDEN;
 		return $qa_content;
 	}
 

--- a/forum/qa-include/qa-page-not-found.php
+++ b/forum/qa-include/qa-page-not-found.php
@@ -34,7 +34,7 @@
 	$qa_content=qa_content_prepare();
 	$qa_content['error']=qa_lang_html('main/page_not_found');
 	$qa_content['suggest_next']=qa_html_suggest_qs_tags(qa_using_tags());
-	$qa_content['http_status']=404;
+	$qa_content['http_status']=Q2A_Response::STATUS_NOT_FOUND;
 
 
 	return $qa_content;

--- a/forum/qa-include/qa-page-not-found.php
+++ b/forum/qa-include/qa-page-not-found.php
@@ -28,13 +28,13 @@
 	require_once QA_INCLUDE_DIR.'app/format.php';
 
 
-	header('HTTP/1.0 404 Not Found');
 
 	qa_set_template('not-found');
 
 	$qa_content=qa_content_prepare();
 	$qa_content['error']=qa_lang_html('main/page_not_found');
 	$qa_content['suggest_next']=qa_html_suggest_qs_tags(qa_using_tags());
+	$qa_content['http_status']=404;
 
 
 	return $qa_content;

--- a/forum/qa-include/qa-page.php
+++ b/forum/qa-include/qa-page.php
@@ -403,7 +403,7 @@
 		$themeclass->initialize();
 
 		header('Content-type: '.$qa_content['content_type']);
-		http_response_code($qa_content['http_status'] ?? 200);
+		http_response_code($qa_content['http_status'] ?? Q2A_Response::STATUS_OK);
 
 		$themeclass->doctype();
 		$themeclass->html();

--- a/forum/qa-include/qa-page.php
+++ b/forum/qa-include/qa-page.php
@@ -403,6 +403,7 @@
 		$themeclass->initialize();
 
 		header('Content-type: '.$qa_content['content_type']);
+		http_response_code($qa_content['http_status'] ?? 200);
 
 		$themeclass->doctype();
 		$themeclass->html();

--- a/forum/qa-plugin/q2a-change-username-limit/page/account.php
+++ b/forum/qa-plugin/q2a-change-username-limit/page/account.php
@@ -419,6 +419,7 @@ if (!qa_opt('mailing_enabled')) {
 if ($isblocked) {
     unset($qa_content['form_profile']['buttons']['save']);
     $qa_content['error']=qa_lang_html('users/no_permission');
+    $qa_content['http_status']=403;
 }
 
 //	Avatar upload stuff

--- a/forum/qa-plugin/q2a-change-username-limit/page/account.php
+++ b/forum/qa-plugin/q2a-change-username-limit/page/account.php
@@ -419,7 +419,7 @@ if (!qa_opt('mailing_enabled')) {
 if ($isblocked) {
     unset($qa_content['form_profile']['buttons']['save']);
     $qa_content['error']=qa_lang_html('users/no_permission');
-    $qa_content['http_status']=403;
+    $qa_content['http_status']=Q2A_Response::STATUS_FORBIDDEN;
 }
 
 //	Avatar upload stuff

--- a/forum/qa-plugin/q2a-user-activity-plus-master/qa-user-activity.php
+++ b/forum/qa-plugin/q2a-user-activity-plus-master/qa-user-activity.php
@@ -104,7 +104,7 @@ class qa_user_activity
 			if ( $userid === null || $userid < 1 )
 			{
 				$qa_content['error'] = qa_lang_html('useractivity/no_user');
-				$qa_content['http_status'] = 404;
+				$qa_content['http_status'] = Q2A_Response::STATUS_NOT_FOUND;
 				return $qa_content;
 			}
 
@@ -147,7 +147,7 @@ class qa_user_activity
 			if ( $userid === null || $userid < 1 )
 			{
 				$qa_content['error'] = qa_lang_html('useractivity/no_user');
-				$qa_content['http_status'] = 404;
+				$qa_content['http_status'] = Q2A_Response::STATUS_NOT_FOUND;
 				return $qa_content;
 			}
 

--- a/forum/qa-plugin/q2a-user-activity-plus-master/qa-user-activity.php
+++ b/forum/qa-plugin/q2a-user-activity-plus-master/qa-user-activity.php
@@ -103,8 +103,8 @@ class qa_user_activity
 			// show 404 if no such user
 			if ( $userid === null || $userid < 1 )
 			{
-				header('HTTP/1.0 404 Not Found');
 				$qa_content['error'] = qa_lang_html('useractivity/no_user');
+				$qa_content['http_status'] = 404;
 				return $qa_content;
 			}
 
@@ -146,8 +146,8 @@ class qa_user_activity
 			// show 404 if no such user
 			if ( $userid === null || $userid < 1 )
 			{
-				header('HTTP/1.0 404 Not Found');
 				$qa_content['error'] = qa_lang_html('useractivity/no_user');
+				$qa_content['http_status'] = 404;
 				return $qa_content;
 			}
 


### PR DESCRIPTION
W #265 opisałem problem braku kodu 404 dla pytań, których już nie da się zobaczyć, ale robiąc to zauważyłem, że praktycznie nigdzie nie zwracamy kodów HTTP. Dodałem więc przy okazji trochę w części miejsc, gdzie jednoznacznie widać jaki kod mógłby być. Dodawałem tylko z grupy 4XX.

Fixes #265 