### PR TITLE
Poprawka zbędnego pogrubiania treści pisanej w poście po automatycznej adnotacji

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -435,6 +435,7 @@ function qa_ajax_error()
 
     window.addEventListener( 'DOMContentLoaded', () => {
         const qaMainElement = document.querySelector( '.qa-main' );
+        const NON_BREAKING_SPACE_UNICODE = '\u00A0';
 
         if ( qaMainElement ) {
             const addAnnotationToCommentedUser = ( relativeDomRef, ckeCurrentInstance ) => {
@@ -447,9 +448,12 @@ function qa_ajax_error()
                     currentContent = ckeTxt.innerHTML.replace( /[<]strong[>](.*)[,<\/]strong[>]/, '' );
                 }
 
-                ckeTxt.innerHTML = `<strong>@${ chosenCommentAuthor },</strong> ${ currentContent }`;
+                ckeTxt.innerHTML = `<strong>@${ chosenCommentAuthor },</strong>${ currentContent }`;
 
-                return ckeTxt;
+                const annotationSuccessor = document.createTextNode(NON_BREAKING_SPACE_UNICODE);
+                ckeTxt.insertBefore(annotationSuccessor, ckeTxt.querySelector('strong').nextSibling);
+
+                return annotationSuccessor;
             };
 
             const setCursorToAnnotationEnd = ( editor, ckeTxt ) => {


### PR DESCRIPTION
Poprawka do #269.

Nie znam dokładnej przyczyny problemu, więc fix zrobiłem trochę na zasadzie prób i błędów.

Fix polega właściwie na tym, że we [wspomnianej w issue do tego buga](https://github.com/CodersCommunity/forum.pasja-informatyki.local/issues/269#issuecomment-879676106) strukturze HTML adnotacji, usunąłem spację przed `</strong>` i umieściłem ją jako osobny węzeł tekstowy zawierający niełamiącą się spację. Wyjściowo struktura HTML wygląda teraz tak:

```html
<p>
  <strong>@adnotacjaUsera,</strong>
  "&nbsp;"
  <br>
</p>
```

Węzeł z encją `&nbsp;` jest użyty - teraz zamiast całego `<p>` - jako kontekst do metody [`moveToPosition`](https://github.com/CodersCommunity/forum.pasja-informatyki.local/pull/110/files#diff-ebb3c8887d430183438925b441606c0ef029b10ee379834133eccf7e93f6d032R906) i kursor po dodaniu adnotacji jest wstawiany do tego węzła. Dzięki temu pisanie "normalnej" treści posta nie jest niepotrzebnie pogrubiane oraz kursor nie jest wstawiany za `<br>`, co powodowało (przynajmniej na Firefox) zaczynanie pisania od nowej linii.