### PR TITLE
Normalizacja nietypowych tagów podczas zadawania pytania

### DIFF
--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -446,6 +446,7 @@ function set_category_description(idprefix)
 	window.addEventListener('DOMContentLoaded', () => {
 		const tags = document.getElementById('tags');
 		const askQuestionBtn = document.querySelector('input[value="Zadaj pytanie"], input[value="Zapisz"]');
+		const TAGS_SEPARATOR = /\s|,/g;
 		const SPACE_SEPARATOR = ' ';
 		const UNUSUAL_TAGS_MAP = Object.freeze({
 			'c++': 'c-plus-plus',
@@ -454,7 +455,7 @@ function set_category_description(idprefix)
 		if (tags && askQuestionBtn) {
 			askQuestionBtn.addEventListener('click', () => {
 				const normalizedTags = tags.value
-					.split(SPACE_SEPARATOR)
+					.split(TAGS_SEPARATOR)
 					.map((tag) => UNUSUAL_TAGS_MAP[tag.toLowerCase()] || tag)
 					.join(SPACE_SEPARATOR);
 

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -445,7 +445,7 @@ function set_category_description(idprefix)
 ;(function normalizeUnusualTags() {
 	window.addEventListener('DOMContentLoaded', () => {
 		const tags = document.getElementById('tags');
-		const askQuestionBtn = document.querySelector('input[value="Zadaj pytanie"]');
+		const askQuestionBtn = document.querySelector('input[value="Zadaj pytanie"], input[value="Zapisz"]');
 		const SPACE_SEPARATOR = ' ';
 		const UNUSUAL_TAGS_MAP = Object.freeze({
 			'c++': 'c-plus-plus',

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -444,3 +444,25 @@ function set_category_description(idprefix)
     } );
 
 } () );
+
+;(function normalizeUnusualTags() {
+	window.addEventListener('DOMContentLoaded', () => {
+		const tags = document.getElementById('tags');
+		const askQuestionBtn = document.querySelector('input[value="Zadaj pytanie"]');
+		const SPACE_SEPARATOR = ' ';
+		const UNUSUAL_TAGS_MAP = Object.freeze({
+			'c++': 'c-plus-plus',
+		});
+
+		if (tags && askQuestionBtn) {
+			askQuestionBtn.addEventListener('click', () => {
+				const normalizedTags = tags.value
+					.split(SPACE_SEPARATOR)
+					.map((tag) => UNUSUAL_TAGS_MAP[tag.toLowerCase()] || tag)
+					.join(SPACE_SEPARATOR);
+
+				tags.value = normalizedTags;
+			});
+		}
+	});
+})();

--- a/forum/qa-content/qa-ask.js
+++ b/forum/qa-content/qa-ask.js
@@ -342,12 +342,9 @@ function set_category_description(idprefix)
 			}
 		}
 
-		CKEDITOR.on('instanceReady', function(ev)
+		CKEDITOR.on('instanceReady', function(readyEvent)
 		{
-			 var iframe = document.querySelector('iframe[title^="Edytor tekstu sformatowanego"]');
-
-			// get CKEditor DOM from <iframe>
-			var ckeditor = iframe.contentWindow.document.body;
+			var ckeditor = readyEvent.editor.window.$.document.body;
 			var editorFrame = ( document.getElementById( 'cke_content' ) || document.getElementById( 'cke_q_content' ) ).parentNode;
 
 			// when user writes topic title


### PR DESCRIPTION
Poprawka do #254.

Do stałej `UNUSUAL_TAGS_MAP` w razie potrzeby można dodać inne tagi, które są wycinane przez backend, aby skrypt je znormalizował.

---
P.S. Przy okazji - żeby na taką drobnostkę nie tworzyć osobnego PR - poprawiłem też błąd pojawiający się w takcie tworzenia tematu:
> Uncaught TypeError: Cannot read property 'contentWindow' of null (qa-ask.js)

Uniemożliwiał on działanie [ficzera wykrywającego treść SPOJ](https://github.com/CodersCommunity/forum.pasja-informatyki.local/pull/25). Nie wiedzieć czemu, zmieniła się wartość atrybutu `title` - z polskiej na angielską - w `<iframe>` CKEditora. Skrypt nie mógł odczytać `document`u i wykonać dalszych operacji. Zmieniłem to na łapanie `document`u z obiektu zdarzenia przekazywanego do listenera.