### PR TITLE
Bardziej elastyczna konfiguracja portu do WebSocketu

### DIFF
--- a/forum/qa-config-example.php
+++ b/forum/qa-config-example.php
@@ -37,7 +37,12 @@ define('QA_COOKIE_SECURE', false);
 define('QA_RESOURCE_VERSION', null);
 
 define('QA_WS_TOKEN', 'secretKey');
-define('QA_WS_URL', 'http://web_socket:3000');
+/*
+  WebSocket port number should be equal to the Node's one in
+  https://github.com/CodersCommunity/http-websocket-server/blob/master/.env.example
+*/
+define('QA_WS_PORT', 3000);
+define('QA_WS_URL', 'http://web_socket:' . QA_WS_PORT);
 
 define('CHANGE_USERNAME_LIMIT_IN_DAYS', 30);
 

--- a/forum/qa-plugin/async-lists/async-lists-layer.php
+++ b/forum/qa-plugin/async-lists/async-lists-layer.php
@@ -6,7 +6,7 @@ class qa_html_theme_layer extends qa_html_theme_base
     {
         if (in_array($this->template, ['qa', 'activity'])) {
             $path = qa_html(QA_HTML_THEME_LAYER_URLTOROOT . 'js/async-questions-list.js?v=' . QA_RESOURCE_VERSION);
-            $this->content['script'][] = '<script>const WS_PORT = ' . QA_WS_PORT . ';</script>';
+            $this->content['script'][] = '<script>window.WS_PORT = ' . QA_WS_PORT . ';</script>';
             $this->content['script'][] = '<script src="' . $path . '" defer></script>';
         }
 

--- a/forum/qa-plugin/async-lists/async-lists-layer.php
+++ b/forum/qa-plugin/async-lists/async-lists-layer.php
@@ -6,6 +6,7 @@ class qa_html_theme_layer extends qa_html_theme_base
     {
         if (in_array($this->template, ['qa', 'activity'])) {
             $path = qa_html(QA_HTML_THEME_LAYER_URLTOROOT . 'js/async-questions-list.js?v=' . QA_RESOURCE_VERSION);
+            $this->content['script'][] = '<script>const WS_PORT = ' . QA_WS_PORT . ';</script>';
             $this->content['script'][] = '<script src="' . $path . '" defer></script>';
         }
 

--- a/forum/qa-plugin/async-lists/js/async-questions-list.js
+++ b/forum/qa-plugin/async-lists/js/async-questions-list.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', function runAsyncQuestionsList() {
 	const { pathname, hostname, protocol } = window.location;
+	const PORT = WS_PORT || 3000;
 	const isMainOrActivityPage = /^$|\/$|^(\/?)activity/.test(pathname);
 
 	if (!isMainOrActivityPage) {
@@ -13,7 +14,7 @@ document.addEventListener('DOMContentLoaded', function runAsyncQuestionsList() {
 
 	function setupWebSocketConnection() {
 		const socketProtocol = protocol === 'https:' ? 'wss' : 'ws';
-		const webSocket = new WebSocket(`${socketProtocol}://${hostname}:3000`);
+		const webSocket = new WebSocket(`${socketProtocol}://${hostname}:${PORT}`);
 		webSocket.addEventListener('open', onOpen);
 		webSocket.addEventListener('message', onMessage);
 		webSocket.addEventListener('close', onClose);

--- a/forum/qa-plugin/async-lists/js/async-questions-list.js
+++ b/forum/qa-plugin/async-lists/js/async-questions-list.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function runAsyncQuestionsList() {
 	const { pathname, hostname, protocol } = window.location;
-	const PORT = WS_PORT || 3000;
+	const PORT = window.WS_PORT || 3000;
 	const isMainOrActivityPage = /^$|\/$|^(\/?)activity/.test(pathname);
 
 	if (!isMainOrActivityPage) {

--- a/web_socket.example.env
+++ b/web_socket.example.env
@@ -1,4 +1,4 @@
-TOKEN=secretKey
+SECRET_TOKEN=secretKey
 PROTOCOL=http
 HOST=localhost
 HTTP_PORT=3000


### PR DESCRIPTION
Konfiguracja portu dla WebSocketa po stronie Q2A i frontu była zahardkodowana - przeniosłem to do zmiennej. Przekazałem też informacje o porcie do frontendu, aby ustawianie portu było spójne po stronie Q2A-frontend.

Takie uspójnienie przydało by się też w pliku konfiguracyjnym [Docker Compose](https://github.com/CodersCommunity/forum.pasja-informatyki.local/blob/master/docker-compose.yml#L40). Tam jest zahardkodowany port 3000, przez co istnieje ryzyko, że przy łączeniu apki po stronie Node z tą w Q2A porty będą miały różne wartości. Są też dwa miejsca, gdzie konfiguracja jest praktycznie zduplikowana: [Q2A web_socket.example.env](https://github.com/CodersCommunity/forum.pasja-informatyki.local/blob/master/web_socket.example.env#L5) vs [Node .env.example](https://github.com/CodersCommunity/http-websocket-server/blob/master/.env.example#L5)

Zauważyłem też literówkę w nazwie zmiennej środowiskowej `TOKEN` w [Q2A](https://github.com/CodersCommunity/forum.pasja-informatyki.local/blob/master/web_socket.example.env#L1) vs [Node](https://github.com/CodersCommunity/http-websocket-server/blob/master/.env.example#L1) - jest ona używana w [configu Node'a](https://github.com/CodersCommunity/http-websocket-server/blob/master/src/config.js#L8).