### PR TITLE
Poprawa layoutu belki wewnątrz bloczka z kodem

### DIFF
--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -531,6 +531,58 @@ const codeBlockInteractiveBar = () => {
                 return copyCodeBtn;
             }
         }
+        
+        class FeaturesDrawer {
+            constructor() {
+                this.domElement = null;
+                this.featuresDrawerBtn = null;
+                this.featureDrawerOffClickListener = this.getFeatureDrawerOffClickListener();
+                this.FEATURES_DRAWER_CLASSES = {
+                    MAIN: 'features-drawer',
+                    HIDDEN: 'features-drawer--hidden',
+                };
+                
+                this.initButton();
+                this.initDOM();
+            }
+    
+            initDOM() {
+                this.domElement = document.createElement('div');
+                this.domElement.classList.add(this.FEATURES_DRAWER_CLASSES.MAIN, this.FEATURES_DRAWER_CLASSES.HIDDEN);
+            }
+            
+            initButton() {
+                this.featuresDrawerBtn = document.createElement('button');
+                this.featuresDrawerBtn.type = 'button';
+                this.featuresDrawerBtn.textContent = '...';
+                this.featuresDrawerBtn.title = 'Dodatkowe funkcje';
+                this.featuresDrawerBtn.addEventListener('click', () => {
+                    this.domElement.classList.toggle(this.FEATURES_DRAWER_CLASSES.HIDDEN);
+                    
+                    if (this.domElement.classList.contains(this.FEATURES_DRAWER_CLASSES.HIDDEN)) {
+                        document.removeEventListener('click', this.featureDrawerOffClickListener.bind(this), { once: true });
+                    } else {
+                        document.addEventListener('click', this.featureDrawerOffClickListener.bind(this), { once: true });
+                    }
+                });
+            }
+            
+            getFeatureDrawerOffClickListener() {
+                return ({ target }) => {
+                    if (!target.closest(`.${ this.FEATURES_DRAWER_CLASSES.MAIN }`)) {
+                        this.domElement.classList.add(this.FEATURES_DRAWER_CLASSES.HIDDEN);
+                    }
+                }
+            }
+            
+            getFeaturesDrawerBtn() {
+                return this.featuresDrawerBtn;
+            }
+            
+            addFeatures(featureDOMs) {
+                this.domElement.append(...featureDOMs);
+            }
+        }
 
         class CodeBlockFullScreen {
             constructor() {
@@ -623,12 +675,12 @@ const codeBlockInteractiveBar = () => {
                             .catch(console.error);
                     } else {
                         /*
-                            User might exit full screen via ESC or native browser button, instead of 
+                            User might exit full screen via ESC or native browser button, instead of
                             re-using fullScreenBtn, which won't trigger it's click event.
                             Thus, optional post processing is needed in such case.
 
                             await is not used with Promise to prevent code from stoppping it's execution.
-                            Full screen event listener needs to be attached before entering full screen 
+                            Full screen event listener needs to be attached before entering full screen
                             and it needs to run in background, because it waits for user to exit the full screen.
                         */
                         this.listenToFullScreenExitEvent().then(() => {
@@ -717,16 +769,20 @@ const codeBlockInteractiveBar = () => {
         const collapsibleCodeBlocks = new CollapsibleCodeBlocks();
         const languageLabel = new LanguageLabel();
         const codeCopy = new CodeCopy();
-
+        
         return function getCodeBlockBarFeatureItems(codeBlock) {
             const codeBlockFullScreen = new CodeBlockFullScreen();
             codeBlockFullScreen.setupCodeBlockResizeWatcher(codeBlock);
+            const featuresDrawer = new FeaturesDrawer();
+            featuresDrawer.addFeatures([
+                codeBlockFullScreen.getFullScreenBtn(),
+                codeCopy.getCopyToClipboardBtn()
+            ]);
 
             return [
                 languageLabel.getLanguageLabel(codeBlock),
                 collapsibleCodeBlocks.getCodeBlockCollapsingBtn(codeBlock),
-                codeBlockFullScreen.getFullScreenBtn(),
-                codeCopy.getCopyToClipboardBtn()
+                featuresDrawer.getFeaturesDrawerBtn(),
             ].filter(Boolean).map(wrapCodeBlockBarFeatureItem);
         }
 

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -565,8 +565,6 @@ const codeBlockInteractiveBar = () => {
     
                 const { postId, numberInPost } = getCodeBlockMeta(codeBlock);
                 codeHighlightingPostProcessHandler.subscribe(postId, numberInPost, (processedCodeBlock) => {
-                    console.log('??? processedCodeBlock:',processedCodeBlock)
-                    
                     const insertionRef =
                       processedCodeBlock.previousElementSibling.querySelector(`.${ this.FEATURES_DRAWER_CLASSES.BUTTON }`);
     

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -550,6 +550,7 @@ const codeBlockInteractiveBar = () => {
                     MAIN: 'features-drawer',
                     HIDDEN: 'features-drawer--hidden',
                     BUTTON: 'features-drawer__button',
+                    OPENED: 'features-drawer__button--opened',
                     LIST: 'features-drawer__list',
                     LIST_ITEM: 'features-drawer__list-item',
                 };
@@ -582,6 +583,7 @@ const codeBlockInteractiveBar = () => {
             
             toggleDrawer(event) {
                 this.domElement.classList.toggle(this.FEATURES_DRAWER_CLASSES.HIDDEN);
+                this.featuresDrawerBtn.classList.toggle(this.FEATURES_DRAWER_CLASSES.OPENED);
             
                 if (this.domElement.classList.contains(this.FEATURES_DRAWER_CLASSES.HIDDEN)) {
                     document.removeEventListener('click', this.featureDrawerOffClickListener, { once: true });
@@ -597,6 +599,7 @@ const codeBlockInteractiveBar = () => {
                 return ({ target }) => {
                     if (!target.closest(`.${ this.FEATURES_DRAWER_CLASSES.MAIN }`)) {
                         this.domElement.classList.add(this.FEATURES_DRAWER_CLASSES.HIDDEN);
+                        this.featuresDrawerBtn.classList.remove(this.FEATURES_DRAWER_CLASSES.OPENED);
                     }
                 }
             }

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4985,6 +4985,12 @@ pre[class*="brush:"]::after
 	position: relative;
 }
 
+.features-drawer__list-item .content-copy-btn.content-copy-btn--done
+{
+	color: lightgreen;
+	transition: color 0.75s;
+}
+
 .content-copy-btn[disabled]
 {
 	background: lightgray;
@@ -4999,13 +5005,13 @@ pre[class*="brush:"]::after
 .content-copy-tooltip::before
 {
 	position: absolute;
-	background: black;
+	background: red;
 	color: white;
-	font-size: 10px;
-	top: -20px;
+	font-size: 12px;
+	top: -22px;
 	right: -7px;
 	width: 125px;
-	height: 15px;
+	height: 17px;
 	line-height: 15px;
 	font-weight: normal;
 	border-radius: 5px;
@@ -5029,7 +5035,7 @@ pre[class*="brush:"]::after
 	height: 0;
 	top: -5px;
 	right: 30px;
-	border-top: 8px solid black;
+	border-top: 8px solid red;
 	border-right: 8px solid transparent;
 	border-left: 8px solid transparent;
 	position: absolute;

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4796,10 +4796,25 @@ pre[class*="brush:"]::after
 .features-drawer__button {
 	height: 22px;
 	margin-right: 8px;
-	padding: 2px 15px;
+	padding: 2px 30px 2px 15px;
 	border: none;
 	border-radius: 0px 40px;
 	background: #2c3e50;
+	position: relative;
+}
+
+.features-drawer__button::after {
+	content: '';
+	position: absolute;
+	top: 6.7px;
+	right: 12px;
+	border-top: 9px solid white;
+	border-left: 5px solid transparent;
+	border-right: 5px solid transparent;
+}
+
+.features-drawer__button--opened::after {
+	transform: rotate(180deg);
 }
 
 .features-drawer .features-drawer__list {
@@ -5083,8 +5098,6 @@ pre[class*="brush:"]::after
 
 	.syntaxhighlighter-block-bar.is-collapsible .features-drawer__button {
 		border-radius: 0 10px 0 10px;
-		padding-left: 6px;
-		padding-right: 6px;
 	}
 
 	.syntaxhighlighter-block-bar.is-collapsible .features-drawer__button:hover {
@@ -5112,8 +5125,6 @@ pre[class*="brush:"]::after
 
 	.syntaxhighlighter-block-bar:not(.is-collapsible) .features-drawer__button {
 		border-radius: 5px;
-		padding-left: 6px;
-		padding-right: 6px;
 	}
 
 	.syntaxhighlighter-block-bar:not(.is-collapsible) .features-drawer {

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4856,14 +4856,14 @@ pre[class*="brush:"]::after
 	width: 100%;
 }
 
-.syntaxhighlighter-block-bar-item:first-child {
-	min-width: 25%;
-	max-width: 33.3%;
+.syntaxhighlighter-block-bar-item {
+	flex-basis: 30%;
 }
 
 .syntaxhighlighter-block-bar-item:last-child
 {
 	position: relative;
+	display: inline-flex;
 }
 
 .syntaxhighlighter-block-bar-item--hidden,
@@ -4880,6 +4880,7 @@ pre[class*="brush:"]::after
 	font-size: 12px;
 	font-weight: bold;
 	color: white;
+	margin-left: auto;
 }
 
 .syntaxhighlighter-language
@@ -5076,17 +5077,17 @@ pre[class*="brush:"]::after
 	}
 
 	.syntaxhighlighter-block-bar.is-collapsible .syntaxhighlighter-collapsible-button,
-	.syntaxhighlighter-block-bar.is-collapsible .content-copy-btn {
+	.syntaxhighlighter-block-bar.is-collapsible .features-drawer__button {
 		margin: 0 auto 3px;
 	}
 
-	.syntaxhighlighter-block-bar.is-collapsible .content-copy-btn {
+	.syntaxhighlighter-block-bar.is-collapsible .features-drawer__button {
 		border-radius: 0 10px 0 10px;
 		padding-left: 6px;
 		padding-right: 6px;
 	}
 
-	.syntaxhighlighter-block-bar.is-collapsible .content-copy-btn:hover {
+	.syntaxhighlighter-block-bar.is-collapsible .features-drawer__button:hover {
 		background: #476481;
 	}
 }
@@ -5104,15 +5105,19 @@ pre[class*="brush:"]::after
 	}
 
 	.syntaxhighlighter-block-bar:not(.is-collapsible) .syntaxhighlighter-language,
-	.syntaxhighlighter-block-bar:not(.is-collapsible) .content-copy-btn {
+	.syntaxhighlighter-block-bar:not(.is-collapsible) .features-drawer__button {
 		margin: 0;
 		line-height: 1;
 	}
 
-	.syntaxhighlighter-block-bar:not(.is-collapsible) .content-copy-btn {
+	.syntaxhighlighter-block-bar:not(.is-collapsible) .features-drawer__button {
 		border-radius: 5px;
 		padding-left: 6px;
 		padding-right: 6px;
+	}
+
+	.syntaxhighlighter-block-bar:not(.is-collapsible) .features-drawer {
+		right: -22px;
 	}
 }
 

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4783,6 +4783,57 @@ pre[class*="brush:"]::after
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#bf3498db', endColorstr='#bf3498db',GradientType=1 ); /* IE6-9 */
 }
 
+.features-drawer {
+	position: absolute;
+	top: 26px;
+	right: 8px;
+	display: flex;
+	z-index: 1;
+	background: #2c3e50;
+	border-radius: 10px;
+}
+
+.features-drawer__button {
+	height: 22px;
+	margin-right: 8px;
+	padding: 2px 15px;
+	border: none;
+	border-radius: 0px 40px;
+	background: #2c3e50;
+}
+
+.features-drawer .features-drawer__list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	min-width: 62px;
+}
+
+.features-drawer .features-drawer__list .features-drawer__list-item {
+	margin: 0;
+	padding: 10px;
+	display: flex;
+	justify-content: center;
+}
+
+.features-drawer .features-drawer__list .features-drawer__list-item:not(:last-child) {
+	border-bottom: 1px dashed white;
+}
+
+.features-drawer .features-drawer__list button {
+	color: white;
+	margin: 0;
+	padding: 0;
+	white-space: nowrap;
+	background: inherit;
+	border: none;
+}
+
+.features-drawer__button:hover,
+.features-drawer__list button:hover {
+	transform: scale(1.1);
+}
+
 .syntaxhighlighter-parent--center-full-screen {
 	display: flex;
 	flex-direction: column;
@@ -4805,24 +4856,6 @@ pre[class*="brush:"]::after
 	width: 100%;
 }
 
-.syntaxhighlighter-block-bar-item--hidden {
-	display: none;
-}
-
-.syntaxhighlighter-block-bar-item__full-screen-btn {
-	background: none;
-	border: none;
-}
-
-.syntaxhighlighter-block-bar-item__full-screen-btn svg {
-	fill: white;
-}
-
-.syntaxhighlighter-block-bar-item__full-screen-btn:hover {
-	transform: scale(1.25);
-}
-
-
 .syntaxhighlighter-block-bar-item:first-child {
 	min-width: 25%;
 	max-width: 33.3%;
@@ -4830,13 +4863,19 @@ pre[class*="brush:"]::after
 
 .syntaxhighlighter-block-bar-item:last-child
 {
-	display: inline-flex;
-	justify-content: flex-end;
+	position: relative;
 }
+
+.syntaxhighlighter-block-bar-item--hidden,
+.features-drawer--hidden
+{
+	display: none;
+}
+
 
 .syntaxhighlighter-language,
 .syntaxhighlighter-collapsible-button,
-.content-copy-btn
+.features-drawer__button
 {
 	font-size: 12px;
 	font-weight: bold;
@@ -4943,18 +4982,7 @@ pre[class*="brush:"]::after
 
 .content-copy-btn
 {
-	height: 22px;
-	margin-right: 8px;
-	padding: 2px 15px;
-	border: none;
-	border-radius: 0px 40px;
-	outline: none;
-	background: #2c3e50;
 	position: relative;
-}
-
-.content-copy-btn:hover {
-	background: #476481;
 }
 
 .content-copy-btn[disabled]


### PR DESCRIPTION
W nawiązaniu do #276 poprawiłem layout belki. W miejscu przycisku do kopiowania pojawił się nowy przycisk "Opcje", który po kliknięciu rozwija listę dodatkowych ficzerów dla bloczka. Na tą chwilę są to "Pełny ekran" oraz "Kopiowanie". Po środku belki - bez zmian - znajduje się przycisk do (ro)zwijania kodu. Po lewej (również bez zmian) - etykieta dla języka.

**Demo:**

![image](https://user-images.githubusercontent.com/18393526/126726189-c7f0915d-4f70-4a4d-9f4e-6b55a2bccd97.png)
