### PR TITLE
Normalizacja tagów c.d - usuwanie nadmiarowych hashy oraz separacja ich spacją

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -410,15 +410,16 @@ function qa_ajax_error()
 
             if ( askQuestionBtn ) {
                 askQuestionBtn.addEventListener( 'click', () => {
-                    tags.value = tags.value.split( ' ' ).reduce( ( acc, tag, idx, tagsArray ) => {
-                        const extraSpace = idx === tagsArray.length - 1 ? '' : ' ';
-
-                        if ( tag.startsWith( '#' ) ) {
-                            return acc + tag.slice( 1 ) + extraSpace;
-                        } else {
-                            return acc + tag + extraSpace;
-                        }
-                    }, '' );
+                    tags.value = tags.value
+                      // remove hashes from beginning
+                      .replace(/^#*/, '')
+                      // swap: multiple hashes surrounded with spaces -> single space
+                      .replace(/ #+ /g, ' ')
+                      // shrink redundant hashes in a row to a single hash
+                      .replace(/#+/g, '#')
+                      // swap: letters and subsequent hash -> letters, hash and space
+                      .replace(/(\w+#)/g, '$1 ')
+                      .trim();
                 } );
             }
         } );


### PR DESCRIPTION
Poprawka dla issue #284.

Zmiany wprowadzają łańcuszkowego regexa, który:

- usuwa hashe z początku taga
- zamienia wielu hashy otoczonych spacjami na pojedynczą spację
- zamienia wielokrotne hashe na pojedynczy
- zamienia znaki, po których występuje hash na znaki, hash i spację

Przykładowo:
`'###abc# ## d##e fg## h'`
staje się:
`'abc#  d# e fg#  h'`