### PR TITLE
Poprawki dotyczące powiadomienia o nowym wpisie na ścianie profilu

### DIFF
--- a/forum/qa-plugin/async-notifications/async-notifications-page.php
+++ b/forum/qa-plugin/async-notifications/async-notifications-page.php
@@ -29,10 +29,11 @@ class async_notifications_page
                     AND DATE_SUB(CURDATE(),INTERVAL # DAY) <= datetime 
                     AND (
                     (userid=# AND event LIKE "in_%")
-                    OR ((event LIKE "u_message" OR event LIKE "u_wall_post") AND params LIKE "userid=#\t%")
+                    OR ((event LIKE "u_message" OR event LIKE "u_wall_post") AND params LIKE "userid=#\t%" AND userid != #)
                     )',
                     $last_visit,
                     qa_opt('q2apro_onsitenotifications_maxage'),
+                    $userid,
                     $userid,
                     $userid
                 )

--- a/forum/qa-plugin/q2apro-on-site-notifications/q2apro-onsitenotifications-lang-default.php
+++ b/forum/qa-plugin/q2apro-on-site-notifications/q2apro-onsitenotifications-lang-default.php
@@ -48,8 +48,8 @@
 		'in_upvote' => 'Upvote dla',
 		'in_downvote' => 'Downvote dla',
 		'you_received' => 'Odebrano',
-		'message_from' => 'prywatną wiadomość',
-		'wallpost_from' => 'post na ścianie',
+		'message_from' => 'prywatną wiadomość od',
+		'wallpost_from' => 'post na ścianie od',
 	);
 
 

--- a/forum/qa-plugin/q2apro-on-site-notifications/q2apro-onsitenotifications-layer.php
+++ b/forum/qa-plugin/q2apro-on-site-notifications/q2apro-onsitenotifications-layer.php
@@ -120,11 +120,12 @@
 								AND DATE_SUB(CURDATE(),INTERVAL # DAY) <= datetime
 								AND (
 								(userid=# AND event LIKE "in_%")
-								OR ((event LIKE "u_message" OR event LIKE "u_wall_post") AND params LIKE "userid=#\t%")
+								OR ((event LIKE "u_message" OR event LIKE "u_wall_post") AND params LIKE "userid=#\t%" AND userid != #)
 								)
 								',
 								$last_visit,
 								qa_opt('q2apro_onsitenotifications_maxage'),
+								$userid,
 								$userid,
 								$userid
 					)

--- a/forum/qa-plugin/q2apro-on-site-notifications/q2apro-onsitenotifications-page.php
+++ b/forum/qa-plugin/q2apro-on-site-notifications/q2apro-onsitenotifications-page.php
@@ -83,10 +83,11 @@ class q2apro_onsitenotifications_page
 
                 // get message preview by cutting out the string
                 $length = $event['event'] === 'u_message' ? 8 : 5;
+                $key = $event['event'] === 'u_message' ? 'message=' : 'text=';
                 $event['message'] = substr(
                     $ustring,
-                    strpos($ustring, 'message=') + $length,
-                    strlen($ustring) - strpos($ustring, 'message=') + $length
+                    strpos($ustring, $key) + $length,
+                    strlen($ustring) - strpos($ustring, $key) + $length
                 );
 
                 $events[$matches[1] . '_' . $count++] = $event;

--- a/forum/qa-plugin/q2apro-on-site-notifications/q2apro-onsitenotifications-page.php
+++ b/forum/qa-plugin/q2apro-on-site-notifications/q2apro-onsitenotifications-page.php
@@ -53,9 +53,10 @@ class q2apro_onsitenotifications_page
             'SELECT e.event, e.userid, BINARY e.params as params, UNIX_TIMESTAMP(e.datetime) AS datetime
             FROM ^eventlog AS e
             WHERE FROM_UNIXTIME(#) <= datetime AND (e.userid=# AND e.event LIKE "in_%")
-            OR ((e.event LIKE "u_message" OR e.event LIKE "u_wall_post") AND e.params LIKE "userid=#\t%")
+            OR ((e.event LIKE "u_message" OR e.event LIKE "u_wall_post") AND e.params LIKE "userid=#\t%" AND e.userid != #)
             ORDER BY datetime DESC LIMIT #',
             qa_opt('q2apro_onsitenotifications_maxage'), // events of last x days
+            $userid,
             $userid,
             $userid,
             $maxEvents


### PR DESCRIPTION
- Poprawka, aby powiadomienie nie pokazywało się użytkownikowi, który sam dodał wpis na swoją ścianę
- Poprawka podglądu początku treści wpisu na ścianie w title linka
- Poprawka tekstu w powiadomieniu

Fixes #268 