### PR TITLE
Zablokowanie rozszerzenia pól tekstowych na szerokość

### DIFF
--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -1931,6 +1931,7 @@ input[type="submit"], button {
 
 .qa-form-tall-text {
 	width: 100%;
+	resize: vertical;
 }
 
 .qa-form-tall-number, .qa-form-wide-number {


### PR DESCRIPTION
Chodzi o pola jak treść wiadomości prywatnej czy treść formularza kontaktowego, które można było rozszerzyć poza dostępny obszar strony. Teraz tych pól w ogóle nie można zmieniać w poziomie.
Fixes #225 