### PR TITLE
Ukrycie dodatkowej akcji w przypiętych pytaniach

### DIFF
--- a/forum/qa-plugin/q2a-featured-master/qa-featured-layer.php
+++ b/forum/qa-plugin/q2a-featured-master/qa-featured-layer.php
@@ -27,7 +27,8 @@
 					$options=qa_post_html_defaults('Q');
 
 					$q_item = qa_any_to_q_html_fields($question[$id], $userid, qa_cookie_get(), $usershtml, null, $options);
-					
+					unset($q_item['what_2'], $q_item['when_2'], $q_item['who_2']);
+
 					array_unshift($this->content['q_list']['qs'],$q_item);
 				}
 				$this->featured_questions = count($featured);


### PR DESCRIPTION
Problem występuje, gdy pytanie zostało dodane przez jednego użytkownika, a następnie np. edytowane czy przeniesione do innej kategorii przez innego - wtedy na liście pokazywała się również druga akcja bez autora:
![Zrzut ekranu z 2021-09-12 20-54-11](https://user-images.githubusercontent.com/13801608/132999426-debad793-e23f-453e-849c-c34119186d39.png)

Problem jest [tutaj](https://github.com/CodersCommunity/forum.pasja-informatyki.local/blob/master/forum/qa-plugin/q2a-featured-master/qa-featured-layer.php#L26) - w `$usershtml` nie znajduje się wpis dla użytkownika, który dokonał tej dodatkowej akcji, a tylko wpis dla autora. Uznałem jednak, że rozwiązanie jest prostsze - wszystkie pytania na stronie głównej mają po jednej linijce wpisu z akcją, więc nie ma w ogóle powodu, aby tutaj pokazywać drugą akcję, która nie jest w tym miejscu istotna.

Fixes #43