### PR TITLE
Advent of Code - widget i podstrona

### DIFF
--- a/forum/qa-plugin/adventofcode-widget/README.md
+++ b/forum/qa-plugin/adventofcode-widget/README.md
@@ -1,0 +1,3 @@
+# Advent of Code widget
+
+Widget to show results from Advent of Code leaderboard

--- a/forum/qa-plugin/adventofcode-widget/lang/default.php
+++ b/forum/qa-plugin/adventofcode-widget/lang/default.php
@@ -3,6 +3,7 @@
 return [
     'admin_year' => 'Year',
     'admin_leaderboard_id' => 'Leaderboard id',
+    'admin_leaderboard_code' => 'Leaderboard join code',
     'admin_session_id' => 'User session id (from cookie)',
     'admin_save' => 'Save',
     'admin_saved' => 'Saved!',

--- a/forum/qa-plugin/adventofcode-widget/lang/default.php
+++ b/forum/qa-plugin/adventofcode-widget/lang/default.php
@@ -6,4 +6,6 @@ return [
     'admin_session_id' => 'User session id (from cookie)',
     'admin_save' => 'Save',
     'admin_saved' => 'Saved!',
+    'top_users' => 'users',
+    'details_and_full_scores' => 'Details and full scores'
 ];

--- a/forum/qa-plugin/adventofcode-widget/lang/default.php
+++ b/forum/qa-plugin/adventofcode-widget/lang/default.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'admin_enabled' => 'Enabled',
     'admin_year' => 'Year',
     'admin_leaderboard_id' => 'Leaderboard id',
     'admin_leaderboard_code' => 'Leaderboard join code',

--- a/forum/qa-plugin/adventofcode-widget/lang/default.php
+++ b/forum/qa-plugin/adventofcode-widget/lang/default.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'admin_year' => 'Year',
+    'admin_leaderboard_id' => 'Leaderboard id',
+    'admin_session_id' => 'User session id (from cookie)',
+    'admin_save' => 'Save',
+    'admin_saved' => 'Saved!',
+];

--- a/forum/qa-plugin/adventofcode-widget/lang/pl.php
+++ b/forum/qa-plugin/adventofcode-widget/lang/pl.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'admin_year' => 'Rok',
+    'admin_leaderboard_id' => 'Identyfikator tablicy wyników',
+    'admin_session_id' => 'Identyfikator sesji użytkownika (z ciasteczka)',
+    'admin_save' => 'Zapisz',
+    'admin_saved' => 'Zapisano!',
+];

--- a/forum/qa-plugin/adventofcode-widget/lang/pl.php
+++ b/forum/qa-plugin/adventofcode-widget/lang/pl.php
@@ -3,6 +3,7 @@
 return [
     'admin_year' => 'Rok',
     'admin_leaderboard_id' => 'Identyfikator tablicy wyników',
+    'admin_leaderboard_code' => 'Kod dołączenia do tablicy',
     'admin_session_id' => 'Identyfikator sesji użytkownika (z ciasteczka)',
     'admin_save' => 'Zapisz',
     'admin_saved' => 'Zapisano!',

--- a/forum/qa-plugin/adventofcode-widget/lang/pl.php
+++ b/forum/qa-plugin/adventofcode-widget/lang/pl.php
@@ -6,4 +6,6 @@ return [
     'admin_session_id' => 'Identyfikator sesji użytkownika (z ciasteczka)',
     'admin_save' => 'Zapisz',
     'admin_saved' => 'Zapisano!',
+    'top_users' => 'użytkowników',
+    'details_and_full_scores' => 'Szczegóły i pełne wyniki'
 ];

--- a/forum/qa-plugin/adventofcode-widget/lang/pl.php
+++ b/forum/qa-plugin/adventofcode-widget/lang/pl.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'admin_enabled' => 'Włączony',
     'admin_year' => 'Rok',
     'admin_leaderboard_id' => 'Identyfikator tablicy wyników',
     'admin_leaderboard_code' => 'Kod dołączenia do tablicy',

--- a/forum/qa-plugin/adventofcode-widget/metadata.json
+++ b/forum/qa-plugin/adventofcode-widget/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "Advent of Code widget",
+  "uri": "",
+  "description": "Widget to show results from Advent of Code leaderboard",
+  "version": "1.0.0",
+  "date": "2021-11-05",
+  "author": "Forum Pasja Informatyki",
+  "author_uri": "https://forum.pasja-informatyki.pl",
+  "license": "MIT",
+  "update_uri": "",
+  "min_q2a": "1.7",
+  "min_php": "7.0"
+}

--- a/forum/qa-plugin/adventofcode-widget/qa-plugin.php
+++ b/forum/qa-plugin/adventofcode-widget/qa-plugin.php
@@ -20,5 +20,6 @@ if (!defined('QA_VERSION')) {
 }
 
 qa_register_plugin_module('widget', 'src/adventofcode-widget.php', 'adventofcode_widget', 'Advent of Code');
+qa_register_plugin_module('page', 'src/adventofcode-page.php', 'adventofcode_page', 'Advent of Code');
 qa_register_plugin_layer('src/adventofcode-layer.php', 'Advent of Code layer');
 qa_register_plugin_phrases('lang/*.php', 'adventofcode_widget');

--- a/forum/qa-plugin/adventofcode-widget/qa-plugin.php
+++ b/forum/qa-plugin/adventofcode-widget/qa-plugin.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+    Plugin Name: Advent of Code widget
+    Plugin URI:
+    Plugin Description: Widget to show results from Advent of Code leaderboard
+    Plugin Version: 1.0.0
+    Plugin Date: 2021-11-05
+    Plugin Author: Forum Pasja Informatyki
+    Plugin Author URI: https://forum.pasja-informatyki.pl
+    Plugin License: MIT
+    Plugin Minimum Question2Answer Version: 1.7
+    Plugin Minimum PHP Version: 7.0
+    Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) {
+    header('Location: ../../');
+    exit();
+}
+
+qa_register_plugin_module('widget', 'src/adventofcode-widget.php', 'adventofcode_widget', 'Advent of Code');
+qa_register_plugin_layer('src/adventofcode-layer.php', 'Advent of Code layer');
+qa_register_plugin_phrases('lang/*.php', 'adventofcode_widget');

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-layer.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-layer.php
@@ -1,0 +1,15 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+    function head_css()
+    {
+        // TODO css file
+        $this->content['css_src'][] = QA_HTML_THEME_LAYER_URLTOROOT . 'css/style.css';
+
+        // TODO or inline CSS
+        $this->output('<style></style>');
+
+        parent::head_css();
+    }
+}

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-layer.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-layer.php
@@ -4,11 +4,22 @@ class qa_html_theme_layer extends qa_html_theme_base
 {
     function head_css()
     {
-        // TODO css file
-        $this->content['css_src'][] = QA_HTML_THEME_LAYER_URLTOROOT . 'css/style.css';
+        $this->output('<style>
+.aoc-widget {
+    text-align: center;
+    font-size: 14px;
+}
 
-        // TODO or inline CSS
-        $this->output('<style></style>');
+.aoc-widget__title {
+    margin-bottom: 0;
+}
+
+.aoc-widget__ol {
+    padding-left: 23px;
+    text-align: left;
+    font-size: 14px;
+}
+</style>');
 
         parent::head_css();
     }

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-layer.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-layer.php
@@ -4,7 +4,8 @@ class qa_html_theme_layer extends qa_html_theme_base
 {
     function head_css()
     {
-        $this->output('<style>
+        if (qa_opt('adventofcode_widget_enabled') == 1) {
+            $this->output('<style>
 .aoc-widget {
     text-align: center;
     font-size: 14px;
@@ -20,6 +21,7 @@ class qa_html_theme_layer extends qa_html_theme_base
     font-size: 14px;
 }
 </style>');
+        }
 
         parent::head_css();
     }

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -53,13 +53,13 @@ class adventofcode_page
 
             // Ranking
             $html .= '<ol class="aoc-page__ranking">';
-            foreach($users as ['name' => $username, 'score' => $score, 'stars' => $stars]) {
+            foreach($users as ['name' => $username, 'score' => $score, 'stars' => $stars, 'link' => $userlink]) {
                 $html .= '<li>';
                 $html .= '    <span class="aoc-page__score">'.$score.'</span>';
                 foreach($stars as $day => $dayScore) {
                     $html .= '<span class="aoc-page__star aoc-page__star--'.$dayScore.'" title="'.$username.' - Dzień: '.$day.'">*</span>';
                 }
-                $html .= '    <span class="aoc-page__username">'.$username.'</span>';
+                $html .= '    <span class="aoc-page__username">'.$this->wrap_username_in_anchor($username, $userlink).'</span>';
                 $html .= '</li>';
             }
             $html .= '</ol>';
@@ -74,6 +74,10 @@ class adventofcode_page
         $html .= '<p>Powodzenia!</p>';
 
         return $html;
+    }
+
+    private function wrap_username_in_anchor($username, $userlink) {
+        return isset($userlink) ? '<a href="'.$userlink.'" target="_blank">'.$username.'</a>' : $username;
     }
 
     private function get_css()

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -76,7 +76,8 @@ class adventofcode_page
         return $html;
     }
 
-    private function wrap_username_in_anchor($username, $userlink) {
+    private function wrap_username_in_anchor($username, $userlink)
+    {
         return isset($userlink) ? '<a href="'.$userlink.'" target="_blank">'.$username.'</a>' : $username;
     }
 

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -60,7 +60,7 @@ class adventofcode_page
         return '
             .aoc-page__days {
                 list-style-type: none;
-                margin-left: 64px;
+                margin-left: 60px;
                 margin-bottom: 5px;
                 line-height: 1.2em;
             }

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -143,7 +143,7 @@ class adventofcode_page
             }
 
             @media (max-width: 760px) {
-                .aoc-page__users {
+                .aoc-page__star, .aoc-page__days {
                     display: none;
                 }
             }

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -4,7 +4,7 @@ class adventofcode_page
 {
     public function match_request($request)
     {
-        return $request === 'advent-of-code';
+        return $request === 'advent-of-code' && qa_opt('adventofcode_widget_enabled') == 1;
     }
 
     public function process_request()

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -11,18 +11,32 @@ class adventofcode_page
     {
         $users = json_decode(qa_opt('adventofcode_widget_content'), true);
         $users = $this->fill_missing_days($users);
+        $year = qa_opt('adventofcode_widget_year');
 
         $qa_content = qa_content_prepare();
         $qa_content['title'] = 'Advent of Code '.qa_opt('adventofcode_widget_year');
         $qa_content['head_lines'][] = '<style>'.$this->get_css().'</style>';
-        $qa_content['custom'] = $this->get_html($users);
+        $qa_content['custom'] = $this->get_html($users, $year);
 
         return $qa_content;
     }
 
-    private function get_html($users)
+    private function get_html($users, $year)
     {
         $html = '';
+
+        $html .= '<h2>Zapraszamy do wspólnej rywalizacji!</h2>';
+        $html .= '<p><a href="https://adventofcode.com/'.$year.'/about">Advent of Code</a> to coroczne zadania programistyczne, które pojawiają się codziennie przez okres adwentu. Możesz rozwiązywać je w <strong>dowolnym języku programowania</strong>. Nie jest wymagana żadna specjalistyczna wiedza - wystarczą chęci i podstawowa znajomość języka angielskiego.</p>';
+        
+        $html .= '<p>Aby umilić rozgrywkę, przygotowaliśmy prywatną tablicę wyników dla naszej społeczności.</p>';
+
+        $html .= '<p class="aoc-page__join-info">';
+            $html .= '<a href="https://adventofcode.com/'.$year.'/leaderboard/private/view/1155718">Dołącz do tablicy</a>, używając kodu:<br>';
+            $html .= '<span class="aoc-page__lead-board-code">1155718-08565481</span>';
+        $html .= '</p>';
+
+        $html .= '<h2>Ranking</h2>';
+        $html .= 'Każdego dnia jest do zdobycia <b><span class="aoc-page__star aoc-page__star--1">*</span> gwiazdka</b> za rozwiązanie pierwszej części zadania,<br> oraz <b><span class="aoc-page__star aoc-page__star--2">*</span> gwiazdka</b> za rozwiązanie całości. Punkty w rankingu liczone są na podstawie liczby zdobytych gwiazdek i kolejności zgłoszeń.';
 
         // Users
         $html .= '<div class="aoc-page__users">';
@@ -51,6 +65,11 @@ class adventofcode_page
 
         $html .= '</div>';
         // e/o Users
+
+        $html .= '<h2>Discord</h2>';
+        $html .= '<p>Zajrzyj na <a href="/chat-discord">serwer Discorda</a>, gdzie posiadamy specjalny kanał do dyskusji o zadaniach. Prosimy jednak, aby nie wrzucać gotowych rozwiązań i nie oczekiwać, że takie zostaną podane - pozwólmy wszystkim dobrze się bawić, a w razie problemów nakierujmy na właściwy tok myślenia.</p>';
+
+        $html .= '<p>Powodzenia!</p>';
         
         return $html;
     }
@@ -58,6 +77,17 @@ class adventofcode_page
     private function get_css()
     {
         return '
+            .aoc-page__join-info {
+                text-align: center;
+                margin: 30px 0 20px;
+            }
+            .aoc-page__users {
+                margin: 40px 0;
+            }
+            .aoc-page__lead-board-code {
+                font-family: monospace;
+                font-size: 2rem;
+            }
             .aoc-page__days {
                 list-style-type: none;
                 margin-left: 60px;

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -6,22 +6,130 @@ class adventofcode_page
     {
         return $request === 'advent-of-code';
     }
-
+    
     public function process_request()
     {
-        $qa_content = qa_content_prepare();
-        $qa_content['head_lines'][] = '<style></style>'; // TODO css
-        $qa_content['title'] = 'Advent of Code ' . qa_opt('adventofcode_widget_year');
-
-        $output = '<ol>';
         $users = json_decode(qa_opt('adventofcode_widget_content'), true);
-        foreach($users as $user) {
-            $output .= '<li><b>' . $user['score'] . 'p.</b> - ' . $user['name'] . '</li>';
-        }
-        $output .= '</ol>';
+        $users = $this->fill_missing_days($users);
 
-        $qa_content['custom'] = $output;
+        $qa_content = qa_content_prepare();
+        $qa_content['title'] = 'Advent of Code '.qa_opt('adventofcode_widget_year');
+        $qa_content['head_lines'][] = '<style>'.$this->get_css().'</style>';
+        $qa_content['custom'] = $this->get_html($users);
 
         return $qa_content;
+    }
+
+    private function get_html($users)
+    {
+        $html = '';
+
+        // Users
+        $html .= '<div class="aoc-page__users">';
+        
+            // Days numbers
+            $html .= '<ol class="aoc-page__days">';
+            foreach(range(1, 25) as $dayNr) {
+                $html .= '<li class="aoc-page__day-nr">'.$dayNr.'</li>';
+            }
+            $html .= '</ol>';
+            // e/o Days numbers
+            
+            // Ranking
+            $html .= '<ol class="aoc-page__ranking">';
+            foreach($users as ['name' => $username, 'score' => $score, 'stars' => $stars]) {
+                $html .= '<li>';
+                $html .= '    <span class="aoc-page__score">'.$score.'</span>';
+                foreach($stars as $day => $dayScore) {
+                    $html .= '<span class="aoc-page__star aoc-page__star--'.$dayScore.'" title="'.$username.' - Dzień: '.$day.'">*</span>';
+                }
+                $html .= '    <span class="aoc-page__username">'.$username.'</span>';
+                $html .= '</li>';
+            }
+            $html .= '</ol>';
+            // e/o Ranking
+
+        $html .= '</div>';
+        // e/o Users
+        
+        return $html;
+    }
+
+    private function get_css()
+    {
+        return '
+            .aoc-page__days {
+                list-style-type: none;
+                margin-left: 64px;
+                margin-bottom: 5px;
+                line-height: 1.2em;
+            }
+            .aoc-page__ranking {
+                margin-top: 5px;
+            }
+            .aoc-page__day-nr {
+                display: inline-block;
+                width: 10px;
+                margin-right: 2px;
+                word-wrap: break-word;
+            }
+            .aoc-page__star {
+                opacity: 0.2;
+                font-size: 20px;
+                line-height: 0;
+                display: inline-block;
+                width: 12px;
+                position: relative;
+                top: 4px;
+            }
+            .dark-theme .aoc-page__star {
+                font-size: 18px;
+            }
+            .aoc-page__star--1 {
+                opacity: 1;
+                color: #3498db;
+            }
+            .dark-theme .aoc-page__star--1 {
+                opacity: 1;
+            }
+            .aoc-page__star--2 {
+                opacity: 1;
+                color: #e67e22;
+            }
+            .dark-theme .aoc-page__star--2 {
+                color: gold;
+            }
+            .aoc-page__score {
+                display: inline-block;
+                margin-right: 10px;
+                width: 50px;
+                text-align: right;
+            }
+            .aoc-page__username {
+                display: inline-block;
+                margin-left: 8px;
+            }
+
+            @media (max-width: 760px) {
+                .aoc-page__users {
+                    display: none;
+                }
+            }
+        ';
+    }
+
+    private function fill_missing_days($users)
+    {
+        foreach($users as &$user) {
+            $stars = &$user['stars'];
+
+            foreach(range(1, 25) as $day) {
+                $stars[$day] = $stars[$day] ?? 0;
+            }
+
+            ksort($stars);
+        }
+
+        return $users;
     }
 }

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -6,33 +6,35 @@ class adventofcode_page
     {
         return $request === 'advent-of-code';
     }
-    
+
     public function process_request()
     {
         $users = json_decode(qa_opt('adventofcode_widget_content'), true);
         $users = $this->fill_missing_days($users);
         $year = qa_opt('adventofcode_widget_year');
+        $leaderboard = qa_opt('adventofcode_widget_leaderboard_id');
+        $code = qa_opt('adventofcode_widget_leaderboard_code');
 
         $qa_content = qa_content_prepare();
-        $qa_content['title'] = 'Advent of Code '.qa_opt('adventofcode_widget_year');
+        $qa_content['title'] = 'Advent of Code '.$year;
         $qa_content['head_lines'][] = '<style>'.$this->get_css().'</style>';
-        $qa_content['custom'] = $this->get_html($users, $year);
+        $qa_content['custom'] = $this->get_html($users, $year, $leaderboard, $code);
 
         return $qa_content;
     }
 
-    private function get_html($users, $year)
+    private function get_html($users, $year, $leaderboard, $code)
     {
         $html = '';
 
         $html .= '<h2>Zapraszamy do wspólnej rywalizacji!</h2>';
         $html .= '<p><a href="https://adventofcode.com/'.$year.'/about">Advent of Code</a> to coroczne zadania programistyczne, które pojawiają się codziennie przez okres adwentu. Możesz rozwiązywać je w <strong>dowolnym języku programowania</strong>. Nie jest wymagana żadna specjalistyczna wiedza - wystarczą chęci i podstawowa znajomość języka angielskiego.</p>';
-        
+
         $html .= '<p>Aby umilić rozgrywkę, przygotowaliśmy prywatną tablicę wyników dla naszej społeczności.</p>';
 
         $html .= '<p class="aoc-page__join-info">';
-            $html .= '<a href="https://adventofcode.com/'.$year.'/leaderboard/private/view/1155718">Dołącz do tablicy</a>, używając kodu:<br>';
-            $html .= '<span class="aoc-page__lead-board-code">1155718-08565481</span>';
+            $html .= '<a href="https://adventofcode.com/'.$year.'/leaderboard/private/view/' . $leaderboard . '">Dołącz do tablicy</a>, używając kodu:<br>';
+            $html .= '<span class="aoc-page__lead-board-code">' . $code . '</span>';
         $html .= '</p>';
 
         $html .= '<h2>Ranking</h2>';
@@ -40,7 +42,7 @@ class adventofcode_page
 
         // Users
         $html .= '<div class="aoc-page__users">';
-        
+
             // Days numbers
             $html .= '<ol class="aoc-page__days">';
             foreach(range(1, 25) as $dayNr) {
@@ -48,7 +50,7 @@ class adventofcode_page
             }
             $html .= '</ol>';
             // e/o Days numbers
-            
+
             // Ranking
             $html .= '<ol class="aoc-page__ranking">';
             foreach($users as ['name' => $username, 'score' => $score, 'stars' => $stars]) {
@@ -70,7 +72,7 @@ class adventofcode_page
         $html .= '<p>Zajrzyj na <a href="/chat-discord">serwer Discorda</a>, gdzie posiadamy specjalny kanał do dyskusji o zadaniach. Prosimy jednak, aby nie wrzucać gotowych rozwiązań i nie oczekiwać, że takie zostaną podane - pozwólmy wszystkim dobrze się bawić, a w razie problemów nakierujmy na właściwy tok myślenia.</p>';
 
         $html .= '<p>Powodzenia!</p>';
-        
+
         return $html;
     }
 

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -1,0 +1,27 @@
+<?php
+
+class adventofcode_page
+{
+    public function match_request($request)
+    {
+        return $request === 'advent-of-code';
+    }
+
+    public function process_request()
+    {
+        $qa_content = qa_content_prepare();
+        $qa_content['head_lines'][] = '<style></style>'; // TODO css
+        $qa_content['title'] = 'Advent of Code ' . qa_opt('adventofcode_widget_year');
+
+        $output = '<ol>';
+        $users = json_decode(qa_opt('adventofcode_widget_content'), true);
+        foreach($users as $user) {
+            $output .= '<li><b>' . $user['score'] . 'p.</b> - ' . $user['name'] . '</li>';
+        }
+        $output .= '</ol>';
+
+        $qa_content['custom'] = $output;
+
+        return $qa_content;
+    }
+}

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
@@ -29,7 +29,7 @@ class adventofcode_widget
             $themeobject->output('<li><b>'.$user['score'].'p.</b> - '.$user['name'].'</li>');
         }
         $themeobject->output('</ol>');
-        $themeobject->output('<a href="#"">'.qa_lang_html('adventofcode_widget/details_and_full_scores').'</a>');
+        $themeobject->output('<a href="/advent-of-code">'.qa_lang_html('adventofcode_widget/details_and_full_scores').'</a>');
         $themeobject->output('</div>');
 
         return $qa_content;
@@ -117,7 +117,7 @@ class adventofcode_widget
         if (!$data) {
             return null;
         }
-        
+
         $users = [];
         foreach ($data['members'] as $member) {
             $stars = [];

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
@@ -159,9 +159,9 @@ class adventofcode_widget
 
         if($dom->loadHTML($linksResponse, LIBXML_NOWARNING)) {
             foreach($dom->getElementsByTagName('a') as $anchor) {
-                $potenaitlUserLink = $anchor->getAttribute('href');
+                $potentialUserLink = $anchor->getAttribute('href');
                 $potentialUserName = $anchor->textContent;
-                $userLinks[$potentialUserName] = $potenaitlUserLink;
+                $userLinks[$potentialUserName] = $potentialUserLink;
             }
         }
 

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
@@ -4,12 +4,12 @@ class adventofcode_widget
 {
     public function allow_template($template)
     {
-        return true;
+        return $this->is_enabled();
     }
 
     public function allow_region($region)
     {
-        return true;
+        return $this->is_enabled();
     }
 
     public function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
@@ -39,15 +39,23 @@ class adventofcode_widget
     {
         $saved = qa_clicked('adventofcode_widget_save');
         if ($saved) {
+            qa_opt('adventofcode_widget_enabled', empty(qa_post_text('adventofcode_widget_enabled')) ? 0 : 1);
             qa_opt('adventofcode_widget_year', qa_post_text('adventofcode_widget_year'));
             qa_opt('adventofcode_widget_leaderboard_id', qa_post_text('adventofcode_widget_leaderboard_id'));
             qa_opt('adventofcode_widget_leaderboard_code', qa_post_text('adventofcode_widget_leaderboard_code'));
             qa_opt('adventofcode_widget_session_id', qa_post_text('adventofcode_widget_session_id'));
+            qa_opt('adventofcode_widget_update_date', ''); // reset last date to update results immediately
         }
 
         return [
             'ok' => $saved ? qa_lang_html('adventofcode_widget/admin_saved') : null,
             'fields' => [
+                [
+                    'label' => qa_lang_html('adventofcode_widget/admin_enabled'),
+                    'type' => 'checkbox',
+                    'value' => qa_opt('adventofcode_widget_enabled'),
+                    'tags' => 'name="adventofcode_widget_enabled"',
+                ],
                 [
                     'label' => qa_lang_html('adventofcode_widget/admin_year'),
                     'type' => 'number',
@@ -80,6 +88,11 @@ class adventofcode_widget
                 ],
             ]
         ];
+    }
+
+    private function is_enabled()
+    {
+        return qa_opt('adventofcode_widget_enabled') == 1;
     }
 
     private function should_update_results()

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
@@ -18,10 +18,19 @@ class adventofcode_widget
             $this->update_results();
         }
 
-        $content = json_decode(qa_opt('adventofcode_widget_content'), true);
+        $users = json_decode(qa_opt('adventofcode_widget_content'), true);
+        $year = qa_opt('adventofcode_widget_year');
 
-        print_r($content); // TODO testing
-        $themeobject->output('results…');
+        $themeobject->output('<div class="aoc-widget">');
+        $themeobject->output('<h2 class="aoc-widget__title">Advent of Code '.$year.'</h2>');
+        $themeobject->output('<p class="aoc-widget__top-users">Top 15 '.qa_lang_html('adventofcode_widget/top_users').'</p>');
+        $themeobject->output('<ol class="aoc-widget__ol">');
+        foreach(array_slice($users, 0, 15) as $index => $user) {
+            $themeobject->output('<li><b>'.$user['score'].'p.</b> - '.$user['name'].'</li>');
+        }
+        $themeobject->output('</ol>');
+        $themeobject->output('<a href="#"">'.qa_lang_html('adventofcode_widget/details_and_full_scores').'</a>');
+        $themeobject->output('</div>');
 
         return $qa_content;
     }
@@ -94,7 +103,7 @@ class adventofcode_widget
 
         $content = $this->parseAocResponse($aocResponse);
         if ($content) {
-        qa_opt('adventofcode_widget_content', $content); // TODO move to file?
+            qa_opt('adventofcode_widget_content', $content); // TODO move to file?
         }
 
         qa_opt('adventofcode_widget_update_date', (new DateTime())->format('Y-m-d H'));

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
@@ -121,8 +121,8 @@ class adventofcode_widget
         $users = [];
         foreach ($data['members'] as $member) {
             $stars = [];
-            foreach ($member['completion_day_level'] as $day => $stars) {
-                $stars[$day] = count($stars);
+            foreach ($member['completion_day_level'] as $day => $dayScore) {
+                $stars[$day] = count($dayScore);
             }
 
             $users[] = [

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
@@ -1,0 +1,100 @@
+<?php
+
+class adventofcode_widget
+{
+    public function allow_template($template)
+    {
+        return true;
+    }
+
+    public function allow_region($region)
+    {
+        return true;
+    }
+
+    public function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
+    {
+        if ($this->should_update_results()) {
+            $this->update_results();
+        }
+
+        $content = json_decode(qa_opt('adventofcode_widget_content'), true);
+
+        print_r($content); // TODO testing
+        $themeobject->output('results…');
+
+        return $qa_content;
+    }
+
+    public function admin_form()
+    {
+        $saved = qa_clicked('adventofcode_widget_save');
+        if ($saved) {
+            qa_opt('adventofcode_widget_year', qa_post_text('adventofcode_widget_year'));
+            qa_opt('adventofcode_widget_leaderboard_id', qa_post_text('adventofcode_widget_leaderboard_id'));
+            qa_opt('adventofcode_widget_session_id', qa_post_text('adventofcode_widget_session_id'));
+        }
+
+        return [
+            'ok' => $saved ? qa_lang_html('adventofcode_widget/admin_saved') : null,
+            'fields' => [
+                [
+                    'label' => qa_lang_html('adventofcode_widget/admin_year'),
+                    'type' => 'number',
+                    'value' => qa_opt('adventofcode_widget_year'),
+                    'tags' => 'name="adventofcode_widget_year"',
+                ],
+                [
+                    'label' => qa_lang_html('adventofcode_widget/admin_leaderboard_id'),
+                    'type' => 'text',
+                    'value' => qa_opt('adventofcode_widget_leaderboard_id'),
+                    'tags' => 'name="adventofcode_widget_leaderboard_id"',
+                ],
+                [
+                    'label' => qa_lang_html('adventofcode_widget/admin_session_id'),
+                    'type' => 'text',
+                    'value' => qa_opt('adventofcode_widget_session_id'),
+                    'tags' => 'name="adventofcode_widget_session_id"',
+                ]
+            ],
+            'buttons' => [
+                [
+                    'label' => qa_lang_html('adventofcode_widget/admin_save'),
+                    'tags' => 'name="adventofcode_widget_save"'
+                ],
+            ]
+        ];
+    }
+
+    private function should_update_results()
+    {
+        $date = qa_opt('adventofcode_widget_update_date');
+        $now = (new DateTime())->format('Y-m-d H');
+
+        return $date !== $now;
+    }
+
+    private function update_results()
+    {
+        $year = qa_opt('adventofcode_widget_year');
+        $leaderboard = qa_opt('adventofcode_widget_leaderboard_id');
+        $session = qa_opt('adventofcode_widget_session_id');
+
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_URL, "https://adventofcode.com/{$year}/leaderboard/private/view/{$leaderboard}.json");
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_COOKIE, 'session=' . $session);
+        $content = curl_exec($curl);
+        $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        curl_close($curl);
+
+        if ($code !== 200) {
+            return false;
+        }
+
+        qa_opt('adventofcode_widget_content', $content); // TODO move to file?
+        qa_opt('adventofcode_widget_update_date', (new DateTime())->format('Y-m-d H'));
+
+        return true;
+    }
+}

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
@@ -153,6 +153,7 @@ class adventofcode_widget
             return null;
         }
 
+        libxml_use_internal_errors(true);
         $dom = new DOMDocument;
         $userLinks = [];
 

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
@@ -41,6 +41,7 @@ class adventofcode_widget
         if ($saved) {
             qa_opt('adventofcode_widget_year', qa_post_text('adventofcode_widget_year'));
             qa_opt('adventofcode_widget_leaderboard_id', qa_post_text('adventofcode_widget_leaderboard_id'));
+            qa_opt('adventofcode_widget_leaderboard_code', qa_post_text('adventofcode_widget_leaderboard_code'));
             qa_opt('adventofcode_widget_session_id', qa_post_text('adventofcode_widget_session_id'));
         }
 
@@ -58,6 +59,12 @@ class adventofcode_widget
                     'type' => 'text',
                     'value' => qa_opt('adventofcode_widget_leaderboard_id'),
                     'tags' => 'name="adventofcode_widget_leaderboard_id"',
+                ],
+                [
+                    'label' => qa_lang_html('adventofcode_widget/admin_leaderboard_code'),
+                    'type' => 'text',
+                    'value' => qa_opt('adventofcode_widget_leaderboard_code'),
+                    'tags' => 'name="adventofcode_widget_leaderboard_code"',
                 ],
                 [
                     'label' => qa_lang_html('adventofcode_widget/admin_session_id'),
@@ -103,7 +110,7 @@ class adventofcode_widget
 
         $content = $this->parseAocResponse($aocResponse);
         if ($content) {
-            qa_opt('adventofcode_widget_content', $content); // TODO move to file?
+            qa_opt('adventofcode_widget_content', $content);
         }
 
         qa_opt('adventofcode_widget_update_date', (new DateTime())->format('Y-m-d H'));

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-widget.php
@@ -164,6 +164,7 @@ class adventofcode_widget
                 $userLinks[$potentialUserName] = $potentialUserLink;
             }
         }
+        libxml_use_internal_errors(false);
 
         return $userLinks;
     }

--- a/forum/qa-plugin/user-changeable-theme/user-theme-layer.php
+++ b/forum/qa-plugin/user-changeable-theme/user-theme-layer.php
@@ -107,4 +107,21 @@ class qa_html_theme_layer extends qa_html_theme_base
         }
         qa_html_theme_base::head_css();
     }
+
+    public function body_tags()
+    {
+        $class = 'qa-template-'.qa_html($this->template);
+
+        if (isset($this->content['categoryids'])) {
+            foreach ($this->content['categoryids'] as $categoryid)
+                $class .= ' qa-category-'.qa_html($categoryid);
+        }
+
+        if ($this->check_theme()) {
+            $class .= ' dark-theme';
+        }
+
+        $this->output('class="'.$class.' qa-body-js-off"');
+        qa_html_theme_base::body_tags();
+    }
 }


### PR DESCRIPTION
Z okazji zbliżającej się nowej edycji Advent of Code, wraz z @Argeento przygotowaliśmy plugin, który dodaje w sidebarze widget z top 15 osób z rankingu oraz podstronę z krótkim opisem i pełnym rankingiem. Wtyczka automatycznie co godzinę będzie pobierała aktualny ranking z serwera AoC, zapisywała u nas, a następnie prezentowała użytkownikom. Najważniejsze opcje konfigurowalne są w panelu administracyjnym.

Wszelkie sugestie czy uwagi mile widziane. Proponuję uruchomić to na produkcji dzień-dwa przed pierwszym zadaniem, wraz z tym wstawić przypięty temat informacyjny. Dodatkowo można też założyć kanał na Discordzie na ogólnie różnego rodzaju rywalizacje/konkursy.

![Zrzut ekranu z 2021-11-21 20-31-44](https://user-images.githubusercontent.com/13801608/142776464-ef578403-1b1d-43a8-a84d-bd0d643c1577.png)
![Zrzut ekranu z 2021-11-21 20-31-11](https://user-images.githubusercontent.com/13801608/142776468-bb26ed49-793e-4a03-a53f-8749ce097035.png)
![Zrzut ekranu z 2021-11-21 20-35-42](https://user-images.githubusercontent.com/13801608/142776474-b9d6b088-17c7-425b-b90c-85347ccbb581.png)
