### PR TITLE
Log aktywności użytkowników

### DIFF
--- a/forum/qa-plugin/user-activity-log/events-window/css/styles.css
+++ b/forum/qa-plugin/user-activity-log/events-window/css/styles.css
@@ -1,0 +1,7 @@
+.modal-content{
+    display: none;
+}
+
+.open-modal{
+    margin-top: 2%;
+}

--- a/forum/qa-plugin/user-activity-log/events-window/css/styles.css
+++ b/forum/qa-plugin/user-activity-log/events-window/css/styles.css
@@ -5,3 +5,7 @@
 .open-modal{
     margin-top: 2%;
 }
+
+.close-modal{
+    display: block;
+}

--- a/forum/qa-plugin/user-activity-log/events-window/events-info-scripts.js
+++ b/forum/qa-plugin/user-activity-log/events-window/events-info-scripts.js
@@ -1,0 +1,15 @@
+const ModalWindow = ()=>{
+    const modal = document.querySelector('.modal-content');
+    const closeWindow = document.querySelector('.close-modal');
+    const openWindow = document.querySelector('.open-modal');
+
+    openWindow.addEventListener('click', ()=>{
+        modal.style.display = 'block';
+    }, false);
+
+    closeWindow.addEventListener('click', ()=>{
+        modal.style.display = 'none';
+    }, false);
+}
+
+window.onload = ModalWindow

--- a/forum/qa-plugin/user-activity-log/events-window/events-info-scripts.js
+++ b/forum/qa-plugin/user-activity-log/events-window/events-info-scripts.js
@@ -1,15 +1,11 @@
-const ModalWindow = ()=>{
-    const modal = document.querySelector('.modal-content');
-    const closeWindow = document.querySelector('.close-modal');
-    const openWindow = document.querySelector('.open-modal');
+const modal = document.querySelector('.modal-content');
+const closeWindow = document.querySelector('.close-modal');
+const openWindow = document.querySelector('.open-modal');
 
-    openWindow.addEventListener('click', ()=>{
-        modal.style.display = 'block';
-    }, false);
+openWindow.addEventListener('click', ()=>{
+    modal.style.display = 'block';
+}, false);
 
-    closeWindow.addEventListener('click', ()=>{
-        modal.style.display = 'none';
-    }, false);
-}
-
-window.onload = ModalWindow
+closeWindow.addEventListener('click', ()=>{
+    modal.style.display = 'none';
+}, false);

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -82,6 +82,7 @@ return [
     'c_vote_nil' => 'Usunięto głos na komentarz',
     'c_clearflags' => 'Usunięto wszystkie zgłoszenia na komentarz',
     'in_c_question' => 'Ktoś dodał komentarz do pytania',
+    'in_c_answer' => 'Ktoś dodał komentarz do odpowiedzi',
     'in_c_vote_up' => 'Ktoś oddał głos w górę na komentarz',
 
     'a_post' => 'Dodano odpowiedź',

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -11,6 +11,7 @@ return [
     'username' => "nazwa użytkownika",
     'eventType' => 'Typ aktywności',
     'date' => 'Data (opcjonalna)',
+    'count' => ' Maksymalna liczba wyników',
     'search-label' => 'Szukaj',
     'searchResults' => 'Wyniki wyszukiwania: ',
 

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -23,6 +23,7 @@ return [
     'handle' =>' Nazwa Użytkownika',
     'event' => 'Rodzaj aktywności',
     'noResults'=> 'Nie znaleziono żadnych wyników',
+    'goBack' => 'Wróć do formularza',
 
     'EventModalHeader' => "Przykłady Eventów z bazy danych",
     'users' => 'Użytkowników',

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -11,6 +11,82 @@ return [
     'username' => "nazwa użytkownika",
     'eventType' => 'Typ aktywności',
     'search' => 'Szukaj',
-    'searchResults' => 'Wyniki wyszukiwania'
+    'searchResults' => 'Wyniki wyszukiwania: ',
+    
+    //events
 
+    'u_login'=> 'Logowanie',
+    'u_logout'=> 'Wylogowanie',
+    'u_register' => 'Rejestracja',
+    'u_confirmed' => 'Potwierdzono adres email',
+    'u_reset' => 'Zresetowano hasło',
+    'u_save' => 'Zapisano zmiany w szczegółach konta',
+    'u_password' => 'Zapisano hasło',
+    'u_edit' => 'Zmiana szczegółów konta użytkownika',
+    'u_message' => 'Wysłano wiadomość prywatną',
+    'u_wall_post' => 'Dodano wpis na ścianie innego użytkownika',
+    'u_wall_delete' => 'Usunięto wpis na ścianie innego użytkownika',
+    'u_level' => 'Zmieniono poziom innemu użytkownikowi',
+    'u_block' => 'Zablokowano innego użytkownika',
+    'u_unblock' => 'Odblokowano innego użytkownika',
+    'u_favorite' => 'Dodano użytkownika do ulubionych',
+    'u_unfavorite'=> 'Usunięto użytkownika z ulubionych',
+
+    'q_post' => 'Dodano pytanie',
+    'q_edit' => 'Edycja posta',
+    'q_flag' => 'Zgłoszenie pytania',
+    'q_unflag' => 'Anulowano zgłoszenie pytania',
+    'q_queue' => 'Pytanie wysłane do sprawdzenia przez moderację',
+    'q_close' => 'Pytanie zamknięte',
+    'q_reopen' => 'Pytanie ponownie otwarte',
+    'q_hide' => 'Ukryto pytanie',
+    'q_reshow' => 'Ponownie pokazano pytanie',
+    'q_delete' => 'Usunięto pytanie',
+    'q_move' => 'Pytanie przeniesione do innej kategorii',
+    'q_vote_up' => 'Oddano głos w górę na pytanie',
+    'q_vote_down' => 'Oddano głos w dół na pytanie',
+    'q_vote_nil' => 'Usunięto głos na pytanie',
+    'q_favorite' => 'Dodano pytanie do ulubionych',
+    'q_unfavorite' => 'Usunięto pytanie z ulubionych',
+
+
+    'c_post' => 'Dodano komentarz',
+    'c_flag' => "Zgłoszono komentarz",
+    'c_unflag' => 'Anulowano zgłoszenie komentarza',
+    'c_hide' => 'Ukryto komentarz',
+    'c_reshow' => 'Ponownie pokazano komentarz',
+    'c_delete' => 'Usunięto komentarz',
+    'c_vote_up' => 'Oddano głos w górę na komentarz',
+    'c_vote_down' => 'Oddano głos w dół na komentarz',
+    'c_vote_nil' => 'Usunięto głos na komentarz',
+
+    'a_post' => 'Dodano odpowiedź',
+    'a_select' => 'Wybrano najlepszą odpowiedź',
+    'a_unselect'=> 'Odznaczono najlepszą odpowiedź',
+    'a_flag' => 'Zgłoszono odpowiedź',
+    'a_unflag' => 'Anulowano zgłoszenie odpowiedzi',
+    'a_hide' => 'Ukryto odpowiedź',
+    'a_reshow' => 'Ponownie pokazano odpowiedź',
+    'a_delete' => 'Usunięto odpowiedź',
+    'a_vote_up' => 'Oddano głos w górę na odpowiedź',
+    'a_vote_down' => 'Oddano głos w dół na odpowiedź',
+    'a_vote_nil' => 'Usunięto głos na odpowiedź',
+
+    'cat_new' => 'Utworzono nową kategorię',
+    'cat_edit' => 'Edytowano kategorię',
+
+    'ip_block' => 'Zablokowano adres IP',
+    'ip_unblock' => 'Odblokowano adres IP',
+
+    'tag_favorite' => 'Dodano tag  do ulubionych',
+    'tag_unfavorite' => 'Usunięto tag z ulubionych',
+
+    'cat_favorite' => 'Dodano kategorię do ulubionych',
+    'cat_unfavorite' => 'Usunięto kategorię z ulubionych',
+    
+
+    'clearflags' => 'Usunięto wszystkie zgłoszenia',
+    'a_to_c' => 'Zamieniono odpowiedź na komentarz',
+    'feedback' => 'Dodano sugestię przez formularz na stronie',
+    'search'=> 'Wyszukano coś na stronie'
 ];

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -10,8 +10,13 @@ return [
     'ipAdress' => "adres IP",
     'username' => "nazwa użytkownika",
     'eventType' => 'Typ aktywności',
-    'search' => 'Szukaj',
+    'search-label' => 'Szukaj',
     'searchResults' => 'Wyniki wyszukiwania: ',
+
+    'datetime'=>'Data',
+    'ipaddress' => 'Adres IP',
+    'handle' =>' Nazwa Użytkownika',
+    'event' => 'Rodzaj aktywności',
     
     //events
 
@@ -48,6 +53,7 @@ return [
     'q_vote_nil' => 'Usunięto głos na pytanie',
     'q_favorite' => 'Dodano pytanie do ulubionych',
     'q_unfavorite' => 'Usunięto pytanie z ulubionych',
+    'q_clearflags' => 'Usunięto wszystkie zgłoszenia ne pytanie',
 
 
     'c_post' => 'Dodano komentarz',
@@ -59,6 +65,7 @@ return [
     'c_vote_up' => 'Oddano głos w górę na komentarz',
     'c_vote_down' => 'Oddano głos w dół na komentarz',
     'c_vote_nil' => 'Usunięto głos na komentarz',
+    'c_clearflags' => 'Usunięto wszystkie zgłoszenia na komentarz',
 
     'a_post' => 'Dodano odpowiedź',
     'a_select' => 'Wybrano najlepszą odpowiedź',
@@ -71,6 +78,7 @@ return [
     'a_vote_up' => 'Oddano głos w górę na odpowiedź',
     'a_vote_down' => 'Oddano głos w dół na odpowiedź',
     'a_vote_nil' => 'Usunięto głos na odpowiedź',
+    'a_clearflags' => 'Usunięto wszystkie zgłoszenia na odpowiedź',
 
     'cat_new' => 'Utworzono nową kategorię',
     'cat_edit' => 'Edytowano kategorię',
@@ -84,8 +92,6 @@ return [
     'cat_favorite' => 'Dodano kategorię do ulubionych',
     'cat_unfavorite' => 'Usunięto kategorię z ulubionych',
     
-
-    'clearflags' => 'Usunięto wszystkie zgłoszenia',
     'a_to_c' => 'Zamieniono odpowiedź na komentarz',
     'feedback' => 'Dodano sugestię przez formularz na stronie',
     'search'=> 'Wyszukano coś na stronie'

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'linkLabel' => 'Log aktywności',
+    'title' => 'Aktywności użytkowników',
+    'formTitle' => 'Szukaj aktywności',
+    'filters' => 'Filtry',
+    'condition' => 'Nick, IP lub typ zdarzenia',
+    'condition-editor' => 'Nick lub typ zdarzenia',
+    'ipAdress' => "adres IP",
+    'username' => "nazwa użytkownika",
+    'eventType' => 'Typ aktywności',
+    'search' => 'Szukaj',
+    'searchResults' => 'Wyniki wyszukiwania'
+
+];

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -11,6 +11,9 @@ return [
     'username' => "nazwa użytkownika",
     'eventType' => 'Typ aktywności',
     'date' => 'Data (opcjonalna)',
+    'from' => 'Sortuj od:',
+    'oldest' => 'Najstarszych',
+    'newest' => 'Najnowszych',
     'count' => ' Maksymalna liczba wyników',
     'search-label' => 'Szukaj',
     'searchResults' => 'Wyniki wyszukiwania: ',
@@ -20,6 +23,13 @@ return [
     'handle' =>' Nazwa Użytkownika',
     'event' => 'Rodzaj aktywności',
     'noResults'=> 'Nie znaleziono żadnych wyników',
+
+    'EventModalHeader' => "Przykłady Eventów z bazy danych",
+    'users' => 'Użytkowników',
+    'comments' => 'Komentarzy',
+    'answers' => 'Odpowiedzi',
+    'questions' => 'Pytań',
+    'more' => 'Więcej o Eventach',
     
     //events
 

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'linkLabel' => 'Log aktywności',
+    'linkLabel' => 'Aktywności',
     'title' => 'Aktywności użytkowników',
     'formTitle' => 'Szukaj aktywności',
     'filters' => 'Filtry',
@@ -10,6 +10,7 @@ return [
     'ipAdress' => "adres IP",
     'username' => "nazwa użytkownika",
     'eventType' => 'Typ aktywności',
+    'date' => 'Data (opcjonalna)',
     'search-label' => 'Szukaj',
     'searchResults' => 'Wyniki wyszukiwania: ',
 
@@ -17,6 +18,7 @@ return [
     'ipaddress' => 'Adres IP',
     'handle' =>' Nazwa Użytkownika',
     'event' => 'Rodzaj aktywności',
+    'noResults'=> 'Nie znaleziono żadnych wyników',
     
     //events
 
@@ -66,6 +68,7 @@ return [
     'c_vote_down' => 'Oddano głos w dół na komentarz',
     'c_vote_nil' => 'Usunięto głos na komentarz',
     'c_clearflags' => 'Usunięto wszystkie zgłoszenia na komentarz',
+    'in_c_question' => 'Ktoś dodał komentarz do pytania',
 
     'a_post' => 'Dodano odpowiedź',
     'a_select' => 'Wybrano najlepszą odpowiedź',
@@ -79,6 +82,7 @@ return [
     'a_vote_down' => 'Oddano głos w dół na odpowiedź',
     'a_vote_nil' => 'Usunięto głos na odpowiedź',
     'a_clearflags' => 'Usunięto wszystkie zgłoszenia na odpowiedź',
+    'in_a_question' => 'Ktoś odpowiedział na pytanie',
 
     'cat_new' => 'Utworzono nową kategorię',
     'cat_edit' => 'Edytowano kategorię',

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -67,7 +67,7 @@ return [
     'q_vote_nil' => 'Usunięto głos na pytanie',
     'q_favorite' => 'Dodano pytanie do ulubionych',
     'q_unfavorite' => 'Usunięto pytanie z ulubionych',
-    'q_clearflags' => 'Usunięto wszystkie zgłoszenia ne pytanie',
+    'q_clearflags' => 'Usunięto wszystkie zgłoszenia na pytanie',
     'in_q_vote_up' => 'Ktoś oddał głos w górę na pytanie',
 
 
@@ -83,6 +83,7 @@ return [
     'c_clearflags' => 'Usunięto wszystkie zgłoszenia na komentarz',
     'in_c_question' => 'Ktoś dodał komentarz do pytania',
     'in_c_answer' => 'Ktoś dodał komentarz do odpowiedzi',
+    'in_c_comment' => 'Ktoś dodał komentarz do innego komentarza',
     'in_c_vote_up' => 'Ktoś oddał głos w górę na komentarz',
 
     'a_post' => 'Dodano odpowiedź',

--- a/forum/qa-plugin/user-activity-log/lang/pl.php
+++ b/forum/qa-plugin/user-activity-log/lang/pl.php
@@ -57,6 +57,7 @@ return [
     'q_favorite' => 'Dodano pytanie do ulubionych',
     'q_unfavorite' => 'Usunięto pytanie z ulubionych',
     'q_clearflags' => 'Usunięto wszystkie zgłoszenia ne pytanie',
+    'in_q_vote_up' => 'Ktoś oddał głos w górę na pytanie',
 
 
     'c_post' => 'Dodano komentarz',
@@ -70,6 +71,7 @@ return [
     'c_vote_nil' => 'Usunięto głos na komentarz',
     'c_clearflags' => 'Usunięto wszystkie zgłoszenia na komentarz',
     'in_c_question' => 'Ktoś dodał komentarz do pytania',
+    'in_c_vote_up' => 'Ktoś oddał głos w górę na komentarz',
 
     'a_post' => 'Dodano odpowiedź',
     'a_select' => 'Wybrano najlepszą odpowiedź',
@@ -84,6 +86,7 @@ return [
     'a_vote_nil' => 'Usunięto głos na odpowiedź',
     'a_clearflags' => 'Usunięto wszystkie zgłoszenia na odpowiedź',
     'in_a_question' => 'Ktoś odpowiedział na pytanie',
+    'in_a_vote_up' => 'Ktoś oddał głos w górę na odpowiedź',
 
     'cat_new' => 'Utworzono nową kategorię',
     'cat_edit' => 'Edytowano kategorię',
@@ -98,6 +101,7 @@ return [
     'cat_unfavorite' => 'Usunięto kategorię z ulubionych',
     
     'a_to_c' => 'Zamieniono odpowiedź na komentarz',
+    
     'feedback' => 'Dodano sugestię przez formularz na stronie',
     'search'=> 'Wyszukano coś na stronie'
 ];

--- a/forum/qa-plugin/user-activity-log/metadata.json
+++ b/forum/qa-plugin/user-activity-log/metadata.json
@@ -1,10 +1,9 @@
 {
     "name": "User activity log",
     "description": "Admin panel page that shows user activity log",
-    "version": "0.4",
+    "version": "1.0",
     "date": "2017-03-22",
     "author": "wizarddos",
-    "author_uri": "http://www.powerqa.org",
     "license": "GPLv2",
     "min_q2a": "1.5"
 }

--- a/forum/qa-plugin/user-activity-log/metadata.json
+++ b/forum/qa-plugin/user-activity-log/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "User activity log",
     "description": "Admin panel page that shows user activity log",
-    "version": "1.0",
+    "version": "0.4",
     "date": "2017-03-22",
     "author": "wizarddos",
     "author_uri": "http://www.powerqa.org",

--- a/forum/qa-plugin/user-activity-log/metadata.json
+++ b/forum/qa-plugin/user-activity-log/metadata.json
@@ -1,0 +1,10 @@
+{
+    "name": "User activity log",
+    "description": "Admin panel page that shows user activity log",
+    "version": "1.0",
+    "date": "2017-03-22",
+    "author": "wizarddos",
+    "author_uri": "http://www.powerqa.org",
+    "license": "GPLv2",
+    "min_q2a": "1.5"
+}

--- a/forum/qa-plugin/user-activity-log/qa-plugin.php
+++ b/forum/qa-plugin/user-activity-log/qa-plugin.php
@@ -4,6 +4,9 @@ if (!defined('QA_VERSION')) {
     exit;
 }
 qa_register_plugin_overrides('user-activity-log-overrides.php');
+
 qa_register_plugin_module('page', 'user-activity-log.php', 'user_activity_log', 'User activity log');
+
 qa_register_plugin_module('page', 'user-activity-log-search.php', 'user_activity_search', 'User activity log search results');
+
 qa_register_plugin_phrases('lang/*.php', 'user-activity-log');

--- a/forum/qa-plugin/user-activity-log/qa-plugin.php
+++ b/forum/qa-plugin/user-activity-log/qa-plugin.php
@@ -10,3 +10,5 @@ qa_register_plugin_module('page', 'user-activity-log.php', 'user_activity_log', 
 qa_register_plugin_module('page', 'user-activity-log-search.php', 'user_activity_search', 'User activity log search results');
 
 qa_register_plugin_phrases('lang/*.php', 'user-activity-log');
+
+qa_register_plugin_layer('user-activity-log-layer.php', 'users activity log layer');

--- a/forum/qa-plugin/user-activity-log/qa-plugin.php
+++ b/forum/qa-plugin/user-activity-log/qa-plugin.php
@@ -1,0 +1,9 @@
+<?php
+if (!defined('QA_VERSION')) {
+    header('Location: ../../');
+    exit;
+}
+qa_register_plugin_overrides('user-activity-log-overrides.php');
+qa_register_plugin_module('page', 'user-activity-log.php', 'user_activity_log', 'User activity log');
+qa_register_plugin_module('page', 'user-activity-log-search.php', 'user_activity_search', 'User activity log search results');
+qa_register_plugin_phrases('lang/*.php', 'user-activity-log');

--- a/forum/qa-plugin/user-activity-log/user-activity-log-layer.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-layer.php
@@ -1,0 +1,13 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+    function head_script()
+    {
+        parent::head_script();
+        $this->output(
+            '<link rel = "stylesheet" type = "text/css" href = "'. QA_HTML_THEME_LAYER_URLTOROOT .'events-window/css/styles.css" />
+            <script src = "'. QA_HTML_THEME_LAYER_URLTOROOT .'events-window/events-info-scripts.js"></script>
+        ');
+    }
+}

--- a/forum/qa-plugin/user-activity-log/user-activity-log-layer.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-layer.php
@@ -7,7 +7,7 @@ class qa_html_theme_layer extends qa_html_theme_base
         parent::head_script();
         $this->output(
             '<link rel = "stylesheet" type = "text/css" href = "'. QA_HTML_THEME_LAYER_URLTOROOT .'events-window/css/styles.css" />
-            <script src = "'. QA_HTML_THEME_LAYER_URLTOROOT .'events-window/events-info-scripts.js"></script>
+            <script src = "'. QA_HTML_THEME_LAYER_URLTOROOT .'events-window/events-info-scripts.js" defer></script>
         ');
     }
 }

--- a/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
@@ -1,16 +1,13 @@
 <?php
-if (!defined('QA_VERSION')) {
-    header('Location: ../../');
-    exit;
-}
-function qa_admin_sub_navigation() {
-    $navigation = qa_admin_sub_navigation_base();
-    if(qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR) {
-        $navigation['user-activity-log'] = array(
-            'label' => qa_lang_html('user-activity-log/linkLabel'),
-            'url' => qa_path('admin/user-activity-log'),
-            'selected' => (qa_request_part(1) == 'user-activity-log')? true : null,
-        );
-    }
-    return $navigation;
+
+function qa_admin_sub_navigation(){
+    $nav = qa_admin_sub_navigation_base();
+    
+    $nav['user-activity-log'] = array(
+        'label' => qa_lang_html('user-activity-log/linkLabel'),
+        'url' => qa_path('admin/user-activity-log'),
+        'selected' => (qa_request_part(1) == 'user-activity-log')? true : null, 
+    );
+
+    return $nav;
 }

--- a/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
@@ -2,12 +2,13 @@
 
 function qa_admin_sub_navigation(){
     $nav = qa_admin_sub_navigation_base();
-    
-    $nav['user-activity-log'] = array(
-        'label' => qa_lang_html('user-activity-log/linkLabel'),
-        'url' => qa_path('admin/user-activity-log'),
-        'selected' => (qa_request_part(1) == 'user-activity-log')? true : null, 
-    );
+    if(qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR){
+        $nav['user-activity-log'] = array(
+            'label' => qa_lang_html('user-activity-log/linkLabel'),
+            'url' => qa_path('user-activity-log'),
+            'selected' => (qa_request_part(1) == 'user-activity-log')? true : null, 
+        );
+    }
 
     return $nav;
 }

--- a/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
@@ -1,0 +1,16 @@
+<?php
+if (!defined('QA_VERSION')) {
+    header('Location: ../../');
+    exit;
+}
+function qa_admin_sub_navigation() {
+    $navigation = qa_admin_sub_navigation_base();
+    if(qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR) {
+        $navigation['user-activity-log'] = array(
+            'label' => qa_lang_html('user-activity-log/linkLabel'),
+            'url' => qa_path('admin/user-activity-log'),
+            'selected' => (qa_request_part(1) == 'user-activity-log')? true : null,
+        );
+    }
+    return $navigation;
+}

--- a/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
@@ -1,6 +1,7 @@
 <?php
 
-function qa_admin_sub_navigation(){
+function qa_admin_sub_navigation()
+{
     $nav = qa_admin_sub_navigation_base();
     if(qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR){
         $nav['user-activity-log'] = [

--- a/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
@@ -6,7 +6,7 @@ function qa_admin_sub_navigation(){
         $nav['user-activity-log'] = array(
             'label' => qa_lang_html('user-activity-log/linkLabel'),
             'url' => qa_path('user-activity-log'),
-            'selected' => (qa_request_part(1) == 'user-activity-log')? true : null, 
+            'selected' => (qa_request_part(1) == 'user-activity-log'), 
         );
     }
 

--- a/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-overrides.php
@@ -3,11 +3,11 @@
 function qa_admin_sub_navigation(){
     $nav = qa_admin_sub_navigation_base();
     if(qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR){
-        $nav['user-activity-log'] = array(
+        $nav['user-activity-log'] = [
             'label' => qa_lang_html('user-activity-log/linkLabel'),
             'url' => qa_path('user-activity-log'),
             'selected' => (qa_request_part(1) == 'user-activity-log'), 
-        );
+        ];
     }
 
     return $nav;

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -9,6 +9,11 @@ class user_activity_search
     public function match_request($request) 
     {
         $this->searchArr = $_POST;
+        isset($_POST['request']) ? $_SESSION['query'] = $_POST['request'] : null;
+        isset($_POST['date']) ? $_SESSION['date'] = $_POST['date'] : null;
+        isset($_POST['resultsCount']) ? $_SESSION['resultsCount'] = $_POST['resultsCount'] : null;
+        isset($_POST['sortBy']) ? $_SESSION['sortBy'] = $_POST['fromOldest'] : null;
+
         if(!isset($_POST['condition']) || !isset($_POST['resultsCount'])){
             header('Location: ../../');
             exit;
@@ -29,8 +34,10 @@ class user_activity_search
     public function process_request($request)
     {
         $qa_content=qa_content_prepare();
-        $qa_content['title']= qa_lang_html('user-activity-log/searchResults').$this->searchArr['request'];
-        
+        $qa_content['title']= '<a class = "to-right" href = "'.qa_path_to_root().'user-activity-log">'
+            .qa_lang_html('user-activity-log/searchResults')
+            .$this->searchArr['request'].'</a>';
+            
         $qa_content['custom'] = $this->generateResultsTable();
         $qa_content['navigation']['sub']=qa_admin_sub_navigation();
         return $qa_content;

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -9,14 +9,19 @@ class user_activity_search{
     public function match_request($request) 
     {
         $this->userLevel = qa_get_logged_in_level();
+        $this->searchArr = $_POST;
+        if(!isset($_POST['condition'])){
+            header('Location: ../../');
+            exit;
+        }
+
         if($this->userLevel >= QA_USER_LEVEL_EDITOR){
-            $this->searchArr = $_POST;
-            if($this->dbSearch()){
-                
+            if(isset($this->searchArr)){
+                $this->dbSearch();
+                if(isset($this->dbResult)){
+                    return $request == 'admin/user-activity-log-search';
+                }
             }
-            return $request == 'admin/user-activity-log-search';
-        }else{
-            return false;
         }
     }
 
@@ -32,20 +37,57 @@ class user_activity_search{
 
     private function dbSearch()
     {
-        $baseQuery = 'SELECT `datetime`, `ipaddress`, `handle`, `event` FROM qa_eventlog WHERE ';
+        $baseQuery = 'SELECT `datetime`, `ipaddress`, `handle`, `event` FROM qa_eventlog ';
 
         if($this->searchArr['condition'] == 'username'){
-            $finalQuery = $baseQuery.'handle = $';
+            $finalQuery = $baseQuery.'WHERE  handle = $';
         }else if($this->searchArr['condition'] == 'type'){
-            $finalQuery = $baseQuery.'event = $';
+            $finalQuery = $baseQuery.'WHERE event = $';
         }else if($this->searchArr['condition'] == 'ip'){
             if($this->userLevel > QA_USER_LEVEL_EDITOR){
-                $finalQuery = $baseQuery.'ipaddress = $';
+                $finalQuery = $baseQuery.'WHERE ipaddress = $';
             }   
         }
+
+        if($this->searchArr['date'] != ""){
+            $dateArr = explode('-', $this->searchArr['date']);
+
+
+            //print_r($dateArr);
+
+            if(is_numeric($dateArr[0]) && is_numeric($dateArr[0])){
+                $date = $dateArr[0];
+                if(isset($dateArr[1]) && is_numeric($dateArr[1])){
+                    $date = $date.'-'.$dateArr[1];
+                    if(is_numeric($dateArr[2]) && is_numeric($dateArr[2])){
+                        if(strlen($dateArr[2]) > 2){
+                            $time = explode(' ', $dateArr[2]);
+                            $dateArr[2] = $time[0];
+                            $dateArr[3] = $time[1];
+                            
+                        }
+                        
+                        $date = $date.'-'.$dateArr[2];
+                        
+                    }
+                }
+                $finalQuery = $finalQuery.'AND `datetime` LIKE $';
+            }
+
+            //print_r($dateArr);
+        }
         
-        $finalQuery = $finalQuery.' LIMIT 30';
-        $result = qa_db_query_sub($finalQuery, $this->searchArr['request']);
+        
+        
+        
+        $finalQuery = $finalQuery.' ORDER BY `datetime` DESC LIMIT 30';
+        //print_r($finalQuery);
+        if(strpos($finalQuery, 'LIKE')){
+            $result = qa_db_query_sub($finalQuery, $this->searchArr['request'], $this->searchArr['date']."%");
+        }else{
+            $result = qa_db_query_sub($finalQuery, $this->searchArr['request']);
+        }
+       
         
         if(mysqli_num_rows($result) <= 30){
             $fullResultsArray = [];
@@ -66,8 +108,8 @@ class user_activity_search{
         $results = $this->dbResult;
         if($this->userLevel > QA_USER_LEVEL_EDITOR){
             $tableHeader = 
-            "<table><tr><th>".qa_lang_html('user-activity-log/datetime').'</th>'.
-                '<th>'.qa_lang_html('user-activity-log/ipaddress').'</th>'.
+            "<table><tr><th>".qa_lang_html('user-activity-log/datetime').' </th>'.
+                '<th> '.qa_lang_html('user-activity-log/ipaddress').'</th>'.
                 '<th>'.qa_lang_html('user-activity-log/handle').'</th>'.
                 '<th>'.qa_lang_html('user-activity-log/event').'</th>'.
             "</tr>";
@@ -77,20 +119,33 @@ class user_activity_search{
             foreach($results as $row){
                 $tableContent = $tableContent.'<tr>'.
                     '<th>'.$row['datetime'].'</th>'.
-                    '<th>'.$row['ipaddress'].'</th>'.
+                    '<th> &nbsp;'.$row['ipaddress'].'</th>'.
                     '<th>'.$row['handle'].'</th>'.
                     '<th>'.qa_lang_html('user-activity-log/'.$row['event']).'</th>'.
                     '</tr>';
             }
         }else if($this->userLevel == QA_USER_LEVEL_EDITOR){
             $tableHeader = 
-            "<table><tr><th>".qa_lang_html('user-activity-log/datetime').'</th>'
+            "<table><tr><th>".qa_lang_html('user-activity-log/datetime').' </th>'
                 .'<th>'.qa_lang_html('user-activity-log/handle').'</th>'.
                 '<th>'.qa_lang_html('user-activity-log/event').'</th>'.
             "</tr></table>";
+
+            $tableContent = '';
+
+            foreach($results as $row){
+                $tableContent = $tableContent.'<tr>'.
+                    '<th>'.$row['datetime'].'</th>'.
+                    '<th>'.$row['handle'].'</th>'.
+                    '<th>'.qa_lang_html('user-activity-log/'.$row['event']).'</th>'.
+                    '</tr>';
+            }
         }
 
         $table = $tableHeader.$tableContent.'</table>';
+        if(!isset($results[0])){
+            $table = qa_lang_html('user-activity-log/noResults');
+        }
         return $table;
     }
 }

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -17,7 +17,7 @@ class user_activity_search{
             if(isset($this->searchArr)){
                 $this->dbSearch();
                 if(isset($this->dbResult)){
-                    return $request == 'user-activity-log-search';
+                    return $request === 'user-activity-log-search';
                 }
             }
         }else{
@@ -39,29 +39,28 @@ class user_activity_search{
     {
         $baseQuery = 'SELECT `datetime`, `ipaddress`, `handle`, `event` FROM qa_eventlog ';
 
-        if($this->searchArr['condition'] == 'username'){
+        if($this->searchArr['condition'] === 'username'){
             $finalQuery = $baseQuery.'WHERE  handle = $';
-        }else if($this->searchArr['condition'] == 'type'){
+        }else if($this->searchArr['condition'] === 'type'){
             $finalQuery = $baseQuery.'WHERE event = $';
-        }else if($this->searchArr['condition'] == 'ip'){
+        }else if($this->searchArr['condition'] === 'ip'){
             if(qa_get_logged_in_level() > QA_USER_LEVEL_EDITOR){
                 $finalQuery = $baseQuery.'WHERE ipaddress = $';
             }   
         }
 
-        if($this->searchArr['date'] != ""){
+        if(!empty($this->searchArr['date'])){
             $dateArr = explode('-', $this->searchArr['date']);
 
-
-            if(is_numeric($dateArr[0]) && is_numeric($dateArr[0])){
+            if(isset($dateArr[0]) && is_numeric($dateArr[0])){
                 $date = $dateArr[0];
                 if(isset($dateArr[1]) && is_numeric($dateArr[1])){
                     $date = $date.'-'.$dateArr[1];
-                    if(isset($dateArr[2]) && is_numeric($dateArr[2])){
+                    if(isset($dateArr[2])){
                         if(strlen($dateArr[2]) > 2){
-                            $time = explode(' ', $dateArr[2]);
-                            $dateArr[2] = $time[0];
-                            $dateArr[3] = $time[1];
+                            [$day, $hours] = explode(' ', $dateArr[2]);
+                            $dateArr[2] = $day;
+                            $dateArr[3] = $hours;
                         }
                         
                         $date = $date.'-'.$dateArr[2];
@@ -105,15 +104,15 @@ class user_activity_search{
         if(qa_get_logged_in_level() < QA_USER_LEVEL_ADMIN){
            $results = array_filter($unfiltered, function($field){
                 switch($field['event']){
-                    case 'q_vote_up': return ""; break;
-                    case 'q_vote_down': return ""; break;
-                    case 'q_vote_nil': return ""; break;
-                    case 'a_vote_up':return ""; break;
-                    case 'a_vote_down': return ""; break;
-                    case 'a_vote_nil': return ""; break;
-                    case 'c_vote_up': return ""; break;
-                    case 'c_vote_down': return ""; break;
-                    case 'c_vote_nil': return ""; break;
+                    case 'q_vote_up': 
+                    case 'q_vote_down': 
+                    case 'q_vote_nil':
+                    case 'a_vote_up':
+                    case 'a_vote_down': 
+                    case 'a_vote_nil': 
+                    case 'c_vote_up': 
+                    case 'c_vote_down': 
+                    case 'c_vote_nil': 
                     case 'in_q_vote_up' :
                     case 'in_a_vote_up' :
                     case 'in_c_vote_up' :
@@ -149,6 +148,7 @@ class user_activity_search{
                     '</tr>';
             }
         }else if(qa_get_logged_in_level() == QA_USER_LEVEL_EDITOR){
+            
             $tableHeader = 
                 "<table><tr><th>".qa_lang_html('user-activity-log/datetime').' </th>'.
                     '<th>'.qa_lang_html('user-activity-log/handle').'</th>'.

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -92,7 +92,7 @@ class user_activity_search
         $finalQuery .= empty($this->searchArr['request']) ? 'WHERE' : 'AND';
         $finalQuery .= ' event NOT LIKE \'in_%\'';
 
-        if(qa_get_logged_in_level() < QA_USER_LEVEL_MODERATOR){
+        if(qa_get_logged_in_level() < QA_USER_LEVEL_ADMIN){
             $finalQuery .= 'AND event NOT LIKE \'%vote%\'';
             $finalQuery .= 'AND event NOT LIKE \'%flag%\'';
         }

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -4,12 +4,16 @@ class user_activity_search{
     
     private $searchArr;
     private $dbResult;
+    private $userLevel;
 
     public function match_request($request) 
     {
         $this->userLevel = qa_get_logged_in_level();
         if($this->userLevel >= QA_USER_LEVEL_EDITOR){
             $this->searchArr = $_POST;
+            if($this->dbSearch()){
+                
+            }
             return $request == 'admin/user-activity-log-search';
         }else{
             return false;
@@ -21,13 +25,72 @@ class user_activity_search{
         $qa_content=qa_content_prepare();
         $qa_content['title']= qa_lang_html('user-activity-log/searchResults').$this->searchArr['request'];
         
-        $qa_content['custom'] = "";
+        $qa_content['custom'] = $this->generateResultsTable();
         $qa_content['navigation']['sub']=qa_admin_sub_navigation();
         return $qa_content;
     }
 
     private function dbSearch()
     {
+        $baseQuery = 'SELECT `datetime`, `ipaddress`, `handle`, `event` FROM qa_eventlog WHERE ';
+
+        if($this->searchArr['condition'] == 'username'){
+            $finalQuery = $baseQuery.'handle = $';
+        }else if($this->searchArr['condition'] == 'type'){
+            $finalQuery = $baseQuery.'event = $';
+        }else if($this->searchArr['condition'] == 'ip'){
+            if($this->userLevel > QA_USER_LEVEL_EDITOR){
+                $finalQuery = $baseQuery.'ipaddress = $';
+            }   
+        }
         
+        $finalQuery = $finalQuery.' LIMIT 30';
+        $result = qa_db_query_sub($finalQuery, $this->searchArr['request']);
+        
+        if(mysqli_num_rows($result) <= 30){
+            $fullResultsArray = [];
+            while($row = mysqli_fetch_array($result, MYSQLI_ASSOC)){
+                $fullResultsArray[] = $row;
+            }
+            $this->dbResult = $fullResultsArray;
+            return 1;
+        }else{
+            $this->dbResult = $result;
+            return 0;
+        }
+
+    }
+
+    private function generateResultsTable()
+    {
+        $results = $this->dbResult;
+        if($this->userLevel > QA_USER_LEVEL_EDITOR){
+            $tableHeader = 
+            "<table><tr><th>".qa_lang_html('user-activity-log/datetime').'</th>'.
+                '<th>'.qa_lang_html('user-activity-log/ipaddress').'</th>'.
+                '<th>'.qa_lang_html('user-activity-log/handle').'</th>'.
+                '<th>'.qa_lang_html('user-activity-log/event').'</th>'.
+            "</tr>";
+
+            $tableContent = '';
+
+            foreach($results as $row){
+                $tableContent = $tableContent.'<tr>'.
+                    '<th>'.$row['datetime'].'</th>'.
+                    '<th>'.$row['ipaddress'].'</th>'.
+                    '<th>'.$row['handle'].'</th>'.
+                    '<th>'.qa_lang_html('user-activity-log/'.$row['event']).'</th>'.
+                    '</tr>';
+            }
+        }else if($this->userLevel == QA_USER_LEVEL_EDITOR){
+            $tableHeader = 
+            "<table><tr><th>".qa_lang_html('user-activity-log/datetime').'</th>'
+                .'<th>'.qa_lang_html('user-activity-log/handle').'</th>'.
+                '<th>'.qa_lang_html('user-activity-log/event').'</th>'.
+            "</tr></table>";
+        }
+
+        $table = $tableHeader.$tableContent.'</table>';
+        return $table;
     }
 }

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -1,6 +1,7 @@
 <?php
 
-class user_activity_search{
+class user_activity_search
+{
     
     private $searchArr;
     private $dbResult;
@@ -37,7 +38,7 @@ class user_activity_search{
 
     private function dbSearch()
     {
-        $baseQuery = 'SELECT `datetime`, `ipaddress`, `handle`, `event` FROM qa_eventlog ';
+        $baseQuery = 'SELECT `datetime`, `ipaddress`, `handle`, `event`,`params` FROM qa_eventlog ';
 
         if($this->searchArr['condition'] === 'username'){
             $finalQuery = $baseQuery.'WHERE  handle = $';
@@ -73,11 +74,12 @@ class user_activity_search{
         
         
         if(!is_numeric($this->searchArr['resultsCount'])){
-            $this->dbResult = [];
-            return 0;
+            $this->searchArr['resultsCount'] = 45;
         }
+        $finalQuery = $finalQuery.' ORDER BY `datetime`';
+        $this->searchArr['fromOldest'] ? $finalQuery = $finalQuery.' DESC' : $finalQuery = $finalQuery.' ASC';
         
-        $finalQuery = $finalQuery.' ORDER BY `datetime` DESC LIMIT #';
+        $finalQuery = $finalQuery.' LIMIT #';
         if(strpos($finalQuery, 'LIKE')){
             $result = qa_db_query_sub($finalQuery, $this->searchArr['request'], $this->searchArr['date']."%", $this->searchArr['resultsCount']);
         }else{
@@ -129,39 +131,32 @@ class user_activity_search{
             $results = $unfiltered;
         }
 
-        if(qa_get_logged_in_level() > QA_USER_LEVEL_EDITOR){
-            $tableHeader = 
-                "<table><tr><th>".qa_lang_html('user-activity-log/datetime').' </th>'.
-                    '<th> '.qa_lang_html('user-activity-log/ipaddress').'</th>'.
-                    '<th>'.qa_lang_html('user-activity-log/handle').'</th>'.
-                    '<th>'.qa_lang_html('user-activity-log/event').'</th>'.
-                "</tr>";
+        $tableHeader = 
+        "<table><tr><th>".qa_lang_html('user-activity-log/datetime').' </th>'.
+            '<th>'.qa_lang_html('user-activity-log/handle').'</th>'.
+            '<th>'.qa_lang_html('user-activity-log/event').'</th>';
 
-            $tableContent = '';
+        $tableContent = '';
+
+        if(qa_get_logged_in_level() > QA_USER_LEVEL_EDITOR){
+            $tableHeader = $tableHeader.'<th> '.qa_lang_html('user-activity-log/ipaddress').'</th>'.
+                "</tr>";
 
             foreach($results as $row){
                 $tableContent = $tableContent.'<tr>'.
-                    '<th>'.$row['datetime'].'</th>'.
-                    '<th> &nbsp;'.$row['ipaddress'].'</th>'.
-                    '<th>'.$row['handle'].'</th>'.
-                    '<th>'.qa_lang_html('user-activity-log/'.$row['event']).'</th>'.
+                    '<td>'.$row['datetime'].'</td>'.
+                    '<td>'.$row['handle'].'</td>'.
+                    '<td>'.qa_lang_html('user-activity-log/'.$row['event']).'</td>'.
+                    '<td> &nbsp;'.$row['ipaddress'].'</td>'.
                     '</tr>';
             }
         }else if(qa_get_logged_in_level() == QA_USER_LEVEL_EDITOR){
-            
-            $tableHeader = 
-                "<table><tr><th>".qa_lang_html('user-activity-log/datetime').' </th>'.
-                    '<th>'.qa_lang_html('user-activity-log/handle').'</th>'.
-                    '<th>'.qa_lang_html('user-activity-log/event').'</th>'.
-                "</tr>";
-
-            $tableContent = '';
-
+            $tableHeader = $tableHeader.'</tr>';
             foreach($results as $row){
                 $tableContent = $tableContent.'<tr>'.
-                    '<th>'.$row['datetime'].'</th>'.
-                    '<th>'.$row['handle'].'</th>'.
-                    '<th>'.qa_lang_html('user-activity-log/'.$row['event']).'</th>'.
+                    '<td>'.$row['datetime'].'</td>'.
+                    '<td>'.$row['handle'].'</td>'.
+                    '<td>'.qa_lang_html('user-activity-log/'.$row['event']).'</td>'.
                     '</tr>';
             }
         }

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -40,14 +40,18 @@ class user_activity_search
     {
         $baseQuery = 'SELECT `datetime`, `ipaddress`, `handle`, `event`,`params` FROM qa_eventlog ';
 
-        if($this->searchArr['condition'] === 'username'){
-            $finalQuery = $baseQuery.'WHERE  handle = $';
-        }else if($this->searchArr['condition'] === 'type'){
-            $finalQuery = $baseQuery.'WHERE event = $';
-        }else if($this->searchArr['condition'] === 'ip'){
-            if(qa_get_logged_in_level() > QA_USER_LEVEL_EDITOR){
-                $finalQuery = $baseQuery.'WHERE ipaddress = $';
-            }   
+        if(!empty($this->searchArr['request'])){
+            if($this->searchArr['condition'] === 'username'){
+                $finalQuery = $baseQuery.'WHERE handle = $ ';
+            }else if($this->searchArr['condition'] === 'type'){
+                $finalQuery = $baseQuery.'WHERE event = $ ';
+            }else if($this->searchArr['condition'] === 'ip'){
+                if(qa_get_logged_in_level() > QA_USER_LEVEL_EDITOR){
+                    $finalQuery = $baseQuery.'WHERE ipaddress = $ ';
+                }   
+            }
+        }else{
+            $finalQuery = $baseQuery;
         }
 
         if(!empty($this->searchArr['date'])){
@@ -73,7 +77,7 @@ class user_activity_search
         }
         
         
-        if(!is_numeric($this->searchArr['resultsCount'])){
+        if(!is_numeric($this->searchArr['resultsCount']) || empty($this->searchArr['resultsCount'])){
             $this->searchArr['resultsCount'] = 45;
         }
         $finalQuery = $finalQuery.' ORDER BY `datetime`';
@@ -81,9 +85,17 @@ class user_activity_search
         
         $finalQuery = $finalQuery.' LIMIT #';
         if(strpos($finalQuery, 'LIKE')){
-            $result = qa_db_query_sub($finalQuery, $this->searchArr['request'], $this->searchArr['date']."%", $this->searchArr['resultsCount']);
+            if(empty($this->searchArr['request'])){
+                $result = qa_db_query_sub($finalQuery, $this->searchArr['date']."%", $this->searchArr['resultsCount']);
+            }else{
+                $result = qa_db_query_sub($finalQuery, $this->searchArr['request'], $this->searchArr['date']."%", $this->searchArr['resultsCount']);
+            }
         }else{
-            $result = qa_db_query_sub($finalQuery, $this->searchArr['request'], $this->searchArr['resultsCount']);
+            if(empty($this->searchArr['request'])){
+                $result = qa_db_query_sub($finalQuery, $this->searchArr['resultsCount']);
+            }else{
+                $result = qa_db_query_sub($finalQuery, $this->searchArr['request'], $this->searchArr['resultsCount']);
+            }
         }
        
         if(mysqli_num_rows($result) <= $this->searchArr['resultsCount']){

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -44,7 +44,7 @@ class user_activity_search{
         }else if($this->searchArr['condition'] == 'type'){
             $finalQuery = $baseQuery.'WHERE event = $';
         }else if($this->searchArr['condition'] == 'ip'){
-            if($this->userLevel > QA_USER_LEVEL_EDITOR){
+            if(qa_get_logged_in_level() > QA_USER_LEVEL_EDITOR){
                 $finalQuery = $baseQuery.'WHERE ipaddress = $';
             }   
         }
@@ -114,6 +114,9 @@ class user_activity_search{
                     case 'c_vote_up': return ""; break;
                     case 'c_vote_down': return ""; break;
                     case 'c_vote_nil': return ""; break;
+                    case 'in_q_vote_up' :
+                    case 'in_a_vote_up' :
+                    case 'in_c_vote_up' :
                     case 'q_flag':
                     case 'a_flag':
                     case 'c_flag':

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -3,6 +3,7 @@
 class user_activity_search{
     
     private $searchArr;
+    private $dbResult;
 
     public function match_request($request) 
     {
@@ -18,10 +19,15 @@ class user_activity_search{
     public function process_request($request)
     {
         $qa_content=qa_content_prepare();
-        $qa_content['title']= qa_lang_html('user-activity-log/title');
+        $qa_content['title']= qa_lang_html('user-activity-log/searchResults').$this->searchArr['request'];
         
-        
+        $qa_content['custom'] = "";
         $qa_content['navigation']['sub']=qa_admin_sub_navigation();
         return $qa_content;
+    }
+
+    private function dbSearch()
+    {
+        
     }
 }

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -10,7 +10,7 @@ class user_activity_search{
     {
         $this->userLevel = qa_get_logged_in_level();
         $this->searchArr = $_POST;
-        if(!isset($_POST['condition'])){
+        if(!isset($_POST['condition']) || !isset($_POST['resultsCount'])){
             header('Location: ../../');
             exit;
         }
@@ -77,17 +77,20 @@ class user_activity_search{
         }
         
         
+        if(!is_numeric($this->searchArr['resultsCount'])){
+            $this->dbResult = [];
+            return 0;
+        }
         
-        
-        $finalQuery = $finalQuery.' ORDER BY `datetime` DESC LIMIT 30';
+        $finalQuery = $finalQuery.' ORDER BY `datetime` DESC LIMIT #';
         if(strpos($finalQuery, 'LIKE')){
-            $result = qa_db_query_sub($finalQuery, $this->searchArr['request'], $this->searchArr['date']."%");
+            $result = qa_db_query_sub($finalQuery, $this->searchArr['request'], $this->searchArr['date']."%", $this->searchArr['resultsCount']);
         }else{
-            $result = qa_db_query_sub($finalQuery, $this->searchArr['request']);
+            $result = qa_db_query_sub($finalQuery, $this->searchArr['request'], $this->searchArr['resultsCount']);
         }
        
         
-        if(mysqli_num_rows($result) <= 30){
+        if(mysqli_num_rows($result) <= $this->searchArr['resultsCount']){
             $fullResultsArray = [];
             while($row = mysqli_fetch_array($result, MYSQLI_ASSOC)){
                 $fullResultsArray[] = $row;

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -200,7 +200,7 @@ class user_activity_search
         return $table;
     }
 
-    private function validateDate($finalQuery)
+    private function validateDate(string $finalQuery)
     {
         $isValid = true;
 
@@ -230,7 +230,7 @@ class user_activity_search
         return $isValid ? $finalQuery.' `datetime` LIKE $' : $finalQuery;
     }
 
-    private function findUsersID($user)
+    private function findUsersID(string $user)
     {
         $query = "SELECT `handle`, `userid` FROM `qa_users` WHERE `handle` = $";
 
@@ -239,7 +239,7 @@ class user_activity_search
         return $result['userid'];
     }
 
-    private function findUsersPostsLinks($event, $params)
+    private function findUsersPostsLinks(string $event,string $params)
     {
         $first = substr($event, 0, 1);
         if($first != 'q' && $first != 'a' && $first != 'c'){
@@ -287,7 +287,7 @@ class user_activity_search
         }
     }
 
-    private function findParentPost($parentsid)
+    private function findParentPost(int $parentsid)
     {
         $query = "SELECT `title`, `type`, `parentid` FROM `qa_posts` WHERE `postid` = $";
         $stmt = qa_db_query_sub($query, $parentsid);

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -15,11 +15,11 @@ class user_activity_search
         $_SESSION['sortBy'] = qa_sanitize_html($_POST['fromOldest']) ?? null;
 
         $this->searchArr = [
-            'request' => $_SESSION['query'],
-            'condition' => $_SESSION['condition'],
-            'date' => $_SESSION['date'], 
-            'resultsCount' => $_SESSION['resultsCount'], 
-            'fromOldest' => $_SESSION['sortBy']
+            'request' => qa_sanitize_html($_SESSION['query']),
+            'condition' => qa_sanitize_html($_SESSION['condition']),
+            'date' => qa_sanitize_html($_SESSION['date']), 
+            'resultsCount' => qa_sanitize_html($_SESSION['resultsCount']), 
+            'fromOldest' => qa_sanitize_html($_SESSION['sortBy'])
         ];
         if(!isset($_POST['condition']) || !isset($_POST['resultsCount'])){
             header('Location: ../../');

--- a/forum/qa-plugin/user-activity-log/user-activity-log-search.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log-search.php
@@ -1,0 +1,27 @@
+<?php
+
+class user_activity_search{
+    
+    private $searchArr;
+
+    public function match_request($request) 
+    {
+        $this->userLevel = qa_get_logged_in_level();
+        if($this->userLevel >= QA_USER_LEVEL_EDITOR){
+            $this->searchArr = $_POST;
+            return $request == 'admin/user-activity-log-search';
+        }else{
+            return false;
+        }
+    }
+
+    public function process_request($request)
+    {
+        $qa_content=qa_content_prepare();
+        $qa_content['title']= qa_lang_html('user-activity-log/title');
+        
+        
+        $qa_content['navigation']['sub']=qa_admin_sub_navigation();
+        return $qa_content;
+    }
+}

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -3,7 +3,7 @@
         header('Location: ../../');
         exit;
     }
-    
+
     require_once QA_INCLUDE_DIR.'app/admin.php';
 
     class user_activity_log 
@@ -13,11 +13,7 @@
 
         public function match_request($request) 
         {
-            if(qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR){
-                return $request == 'user-activity-log';
-            }else{
-                return false;
-            }
+            return qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR && $request === 'user-activity-log';
         }
 
         public function process_request($request) 

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -3,15 +3,13 @@
         header('Location: ../../');
         exit;
     }
+    
     require_once QA_INCLUDE_DIR.'app/admin.php';
-    require_once QA_INCLUDE_DIR.'qa-db-metas.php';
 
     class user_activity_log 
     {
         private $directory;
         private $urltoroot;
-
-
 
         public function match_request($request) 
         {

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -52,7 +52,7 @@
                 'buttons' => array(
                     'submit' => array(
                         'tags' => 'name="search"',
-                        'label' => qa_lang_html('user-activity-log/search'),
+                        'label' => qa_lang_html('user-activity-log/search-label'),
                         'value' => '1',
                     ),
                 ),

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -10,9 +10,18 @@
     {
         private $directory;
         private $urltoroot;
+        private $request;
+        private $date;
+        private $resultsCount;
+        private $sortBy;
 
         public function match_request($request) 
         {
+            isset($_SESSION['query']) ? $this->request = $_SESSION['query'] : null;
+            isset($_SESSION['date']) ? $this->date = $_SESSION['date'] : null;
+            isset($_SESSION['resultsCount']) ? $this->resultsCount = $_SESSION['resultsCount'] : null;
+            isset($_SESSION['sortBy']) ? $this->sortBy = $_SESSION['sortBy'] : null;
+            
             return qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR && $request === 'user-activity-log';
         }
 
@@ -29,7 +38,7 @@
                 'fields' => array(
                     'query' => array(
                         'label' => qa_lang_html('user-activity-log/condition'),
-                        'tags' => 'name="request" ',
+                        'tags' => 'name="request" value="'.$this->request.'"',
                     ),
                     
                     'filter' => array(
@@ -45,12 +54,12 @@
 
                     'date' => array(
                         'label' => qa_lang_html('user-activity-log/date'),
-                        'tags' => 'placeholder=YYYY-MM-DD name=date value=""',
+                        'tags' => 'placeholder=YYYY-MM-DD name=date value="'.$this->date.'"',
                     ),
 
                     'fromOldest' => [
                         'type' => 'select',
-                        'tags'=>'name=fromOldest',
+                        'tags'=>'name=fromOldest value="'.$this->sortBy.'"',
                         'options' => [
                                 0 => qa_lang('user-activity-log/oldest'),
                                 1 => qa_lang('user-activity-log/newest'),
@@ -61,7 +70,7 @@
 
                     'resultsCount' => array(
                         'label'=> qa_lang_html('user-activity-log/count'),
-                        'tags'=> 'name=resultsCount',
+                        'tags'=> 'name=resultsCount value="'.$this->resultsCount.'"',
                     )
                 ),
 

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -93,12 +93,16 @@
             '<section class = "modal-content">
                 <h2>'.qa_lang_html('user-activity-log/EventModalHeader').'</h2>
                     <table>
-                        <tr>
-                            <th>'.qa_lang_html('user-activity-log/users').'</th>
-                            <th>'.qa_lang_html('user-activity-log/questions').'</th>
-                            <th>'.qa_lang_html('user-activity-log/answers').'</th>
-                        </tr>
-                        '.$this->generateEventsTable().'
+                        <thead>
+                            <tr>
+                                <th>'.qa_lang_html('user-activity-log/users').'</th>
+                                <th>'.qa_lang_html('user-activity-log/questions').'</th>
+                                <th>'.qa_lang_html('user-activity-log/answers').'</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            '.$this->generateEventsTable().'
+                        </tbody>
                         </table>
                 <a href = "https://docs.question2answer.org/plugins/modules-event/">'.qa_lang_html('user-activity-log/more').'</a>
                 <button class = "qa-form-wide-button close-modal">Zamknij</button>

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -52,6 +52,11 @@
                     'date' => array(
                         'label' => qa_lang_html('user-activity-log/date'),
                         'tags' => 'placeholder=YYYY-MM-DD name=date value=""',
+                    ),
+
+                    'resultsCount' => array(
+                        'label'=> qa_lang_html('user-activity-log/count'),
+                        'tags'=> 'name=resultsCount required',
                     )
                 ),
 

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -4,25 +4,19 @@
         exit;
     }
     require_once QA_INCLUDE_DIR.'app/admin.php';
+    require_once QA_INCLUDE_DIR.'qa-db-metas.php';
+
     class user_activity_log 
     {
         private $directory;
         private $urltoroot;
         private $userLevel;
 
-        public function load_module($directory, $urltoroot) 
-        {
-            $this->directory=$directory;
-            $this->urltoroot=$urltoroot;
-        }
+
+
         public function match_request($request) 
         {
-            $this->userLevel = qa_get_logged_in_level();
-            if($this->userLevel >= QA_USER_LEVEL_EDITOR){
-                return $request == 'admin/user-activity-log';
-            }else{
-                return false;
-            }
+            return $request == 'admin/user-activity-log';
         }
 
         public function process_request($request) 
@@ -43,9 +37,10 @@
                     
                     'filter' => array(
                         'type' => 'select',
+                        'tags'=>'name=condition',
                         'options' => [
-                            'ip' => $this->userLevel >= QA_USER_LEVEL_MODERATOR ? qa_lang_html('user-activity-log/ipAdress') : null,
                             'username' => qa_lang('user-activity-log/username'),
+                            'ip' => $this->userLevel >= QA_USER_LEVEL_MODERATOR ? qa_lang_html('user-activity-log/ipAdress') : null,
                             'type' => qa_lang('user-activity-log/eventType'),
                         ],
                         'label' => qa_lang_html('user-activity-log/filters'),

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -29,7 +29,7 @@
                 'fields' => array(
                     'query' => array(
                         'label' => qa_lang_html('user-activity-log/condition'),
-                        'tags' => 'name="request" required',
+                        'tags' => 'name="request" ',
                     ),
                     
                     'filter' => array(

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -90,28 +90,26 @@
             }
             $qa_content['navigation']['sub']= qa_admin_sub_navigation();
             $qa_content['custom_2'] = 
-            '<div class = "modal-content">
-                <h1>'.qa_lang_html('user-activity-log/EventModalHeader').'</h1>
-                <p>
+            '<section class = "modal-content">
+                <h2>'.qa_lang_html('user-activity-log/EventModalHeader').'</h2>
                     <table>
                         <tr>
                             <th>'.qa_lang_html('user-activity-log/users').'</th>
                             <th>'.qa_lang_html('user-activity-log/questions').'</th>
                             <th>'.qa_lang_html('user-activity-log/answers').'</th>
                         </tr>
-                        '.$this->genereateEventsTable().'
+                        '.$this->generateEventsTable().'
                         </table>
-                </p>
                 <a href = "https://docs.question2answer.org/plugins/modules-event/">'.qa_lang_html('user-activity-log/more').'</a>
                 <br/>
                 <button class = "qa-form-wide-button close-modal">Zamknij</button>
-            </div>
+            </section>
             <button class = "open-modal qa-form-wide-button">Otwórz informację o Eventach</button>';
         
             return $qa_content;
         }
 
-        private function genereateEventsTable()
+        private function generateEventsTable()
         {
             return '
                 <tr>

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -10,13 +10,16 @@
     {
         private $directory;
         private $urltoroot;
-        private $userLevel;
 
 
 
         public function match_request($request) 
         {
-            return $request == 'admin/user-activity-log';
+            if(qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR){
+                return $request == 'user-activity-log';
+            }else{
+                return false;
+            }
         }
 
         public function process_request($request) 
@@ -32,17 +35,17 @@
                 'fields' => array(
                     'query' => array(
                         'label' => qa_lang_html('user-activity-log/condition'),
-                        'tags' => 'name="request"',
+                        'tags' => 'name="request" required',
                     ),
                     
                     'filter' => array(
                         'type' => 'select',
                         'tags'=>'name=condition',
                         'options' => [
-                            'username' => qa_lang('user-activity-log/username'),
-                            'ip' => qa_lang_html('user-activity-log/ipAdress'),
-                            'type' => qa_lang('user-activity-log/eventType'),
-                        ],
+                                'username' => qa_lang('user-activity-log/username'),
+                                'type' => qa_lang('user-activity-log/eventType'),
+                        ]
+                        ,
                         'label' => qa_lang_html('user-activity-log/filters'),
                     ),
 
@@ -63,6 +66,10 @@
                 ),
 
             );
+
+            if(qa_get_logged_in_level() >= QA_USER_LEVEL_MODERATOR){
+                $qa_content['form']['fields']['filter']['options']['ip'] = qa_lang_html('user-activity-log/ipAdress');
+            }
             $qa_content['navigation']['sub']= qa_admin_sub_navigation();
             return $qa_content;
         }

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -48,9 +48,20 @@
                         'tags' => 'placeholder=YYYY-MM-DD name=date value=""',
                     ),
 
+                    'fromOldest' => [
+                        'type' => 'select',
+                        'tags'=>'name=fromOldest',
+                        'options' => [
+                                0 => qa_lang('user-activity-log/oldest'),
+                                1 => qa_lang('user-activity-log/newest'),
+                        ]
+                        ,
+                        'label' => qa_lang_html('user-activity-log/from'),
+                    ],
+
                     'resultsCount' => array(
                         'label'=> qa_lang_html('user-activity-log/count'),
-                        'tags'=> 'name=resultsCount required',
+                        'tags'=> 'name=resultsCount',
                     )
                 ),
 
@@ -70,6 +81,51 @@
                 $qa_content['form']['fields']['filter']['options']['ip'] = qa_lang_html('user-activity-log/ipAdress');
             }
             $qa_content['navigation']['sub']= qa_admin_sub_navigation();
+            $qa_content['custom_2'] = 
+            '<div class = "modal-content">
+                <h1>'.qa_lang_html('user-activity-log/EventModalHeader').'</h1>
+                <p>
+                    <table>
+                        <tr>
+                            <th>'.qa_lang_html('user-activity-log/users').'</th>
+                            <th>'.qa_lang_html('user-activity-log/questions').'</th>
+                            <th>'.qa_lang_html('user-activity-log/answers').'</th>
+                        </tr>
+                        '.$this->genereateEventsTable().'
+                        </table>
+                </p>
+                <a href = "https://docs.question2answer.org/plugins/modules-event/">'.qa_lang_html('user-activity-log/more').'</a>
+                <br/>
+                <button class = "qa-form-wide-button close-modal">Zamknij</button>
+            </div>
+            <button class = "open-modal qa-form-wide-button">Otwórz informację o Eventach</button>';
+        
             return $qa_content;
+        }
+
+        private function genereateEventsTable()
+        {
+            return '
+                <tr>
+                    <td>u_login - '.qa_lang_html("user-activity-log/u_login").'</td>
+                    <td>q_post - '.qa_lang_html("user-activity-log/q_post").'</td>
+                    <td>a_post - '.qa_lang_html("user-activity-log/a_post").'</td>
+                </tr>
+                <tr>
+                    <td>u_register - '.qa_lang_html("user-activity-log/u_register").'</td>
+                    <td>q_edit - '.qa_lang_html("user-activity-log/q_edit").'</td>
+                    <td>a_select - '.qa_lang_html("user-activity-log/a_select").'</td>
+                </tr>
+                <tr>
+                    <td>u_edit - '.qa_lang_html("user-activity-log/u_edit").'</td>
+                    <td>q_close - '.qa_lang_html("user-activity-log/q_close").'</td>
+                    <td>in_a_question - '.qa_lang_html('user-activity-log/in_a_question').'</td>
+                </tr>
+                <tr>
+                    <td>u_message - '.qa_lang_html("user-activity-log/u_message").'</td>
+                    <td>q_delete - '.qa_lang_html("user-activity-log/q_delete").'</td>
+                    <td>a_delete - '.qa_lang_html("user-activity-log/a_delete").'</td>
+                </tr>
+            ';
         }
     }

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -101,7 +101,6 @@
                         '.$this->generateEventsTable().'
                         </table>
                 <a href = "https://docs.question2answer.org/plugins/modules-event/">'.qa_lang_html('user-activity-log/more').'</a>
-                <br/>
                 <button class = "qa-form-wide-button close-modal">Zamknij</button>
             </section>
             <button class = "open-modal qa-form-wide-button">Otwórz informację o Eventach</button>';

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -1,0 +1,69 @@
+<?php
+    if (!defined('QA_VERSION')) {
+        header('Location: ../../');
+        exit;
+    }
+    require_once QA_INCLUDE_DIR.'app/admin.php';
+    class user_activity_log 
+    {
+        private $directory;
+        private $urltoroot;
+        private $userLevel;
+
+        public function load_module($directory, $urltoroot) 
+        {
+            $this->directory=$directory;
+            $this->urltoroot=$urltoroot;
+        }
+        public function match_request($request) 
+        {
+            $this->userLevel = qa_get_logged_in_level();
+            if($this->userLevel >= QA_USER_LEVEL_EDITOR){
+                return $request == 'admin/user-activity-log';
+            }else{
+                return false;
+            }
+        }
+
+        public function process_request($request) 
+        {
+            $qa_content=qa_content_prepare();
+            $qa_content['title']= qa_lang_html('user-activity-log/title');
+            $qa_content['form']=array(
+                'tags' => 'method="post" action="user-activity-log-search"',
+                'style' => 'wide',
+                'title' => qa_lang_html('user-activity-log/formTitle'),
+                
+
+                'fields' => array(
+                    'query' => array(
+                        'label' => qa_lang_html('user-activity-log/condition'),
+                        'tags' => 'name="request"',
+                    ),
+                    
+                    'filter' => array(
+                        'type' => 'select',
+                        'options' => [
+                            'ip' => $this->userLevel >= QA_USER_LEVEL_MODERATOR ? qa_lang_html('user-activity-log/ipAdress') : null,
+                            'username' => qa_lang('user-activity-log/username'),
+                            'type' => qa_lang('user-activity-log/eventType'),
+                        ],
+                        'label' => qa_lang_html('user-activity-log/filters'),
+                    ),
+                ),
+
+                
+
+                'buttons' => array(
+                    'submit' => array(
+                        'tags' => 'name="search"',
+                        'label' => qa_lang_html('user-activity-log/search'),
+                        'value' => '1',
+                    ),
+                ),
+
+            );
+            $qa_content['navigation']['sub']=qa_admin_sub_navigation();
+            return $qa_content;
+        }
+    }

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -10,17 +10,20 @@
     {
         private $directory;
         private $urltoroot;
+
         private $request;
+        private $condition;
         private $date;
         private $resultsCount;
         private $sortBy;
 
         public function match_request($request) 
         {
-            isset($_SESSION['query']) ? $this->request = $_SESSION['query'] : null;
-            isset($_SESSION['date']) ? $this->date = $_SESSION['date'] : null;
-            isset($_SESSION['resultsCount']) ? $this->resultsCount = $_SESSION['resultsCount'] : null;
-            isset($_SESSION['sortBy']) ? $this->sortBy = $_SESSION['sortBy'] : null;
+            $this->request = $_SESSION['query'] ?? null;
+            $this->condition = $_SESSION['condition'] ?? null;
+            $this->date = $_SESSION['date'] ?? null;
+            $this->resultsCount = $_SESSION['resultsCount'] ?? null;
+            $this->sortBy = $_SESSION['sortBy'] ?? null;
             
             return qa_get_logged_in_level() >= QA_USER_LEVEL_EDITOR && $request === 'user-activity-log';
         }
@@ -34,7 +37,6 @@
                 'style' => 'wide',
                 'title' => qa_lang_html('user-activity-log/formTitle'),
                 
-
                 'fields' => array(
                     'query' => array(
                         'label' => qa_lang_html('user-activity-log/condition'),
@@ -43,7 +45,7 @@
                     
                     'filter' => array(
                         'type' => 'select',
-                        'tags'=>'name=condition',
+                        'tags'=>'name=condition value="'.$this->condition.'"',
                         'options' => [
                                 'username' => qa_lang('user-activity-log/username'),
                                 'type' => qa_lang('user-activity-log/eventType'),
@@ -74,8 +76,6 @@
                     )
                 ),
 
-                
-
                 'buttons' => array(
                     'submit' => array(
                         'tags' => 'name="search"',
@@ -83,7 +83,6 @@
                         'value' => '1',
                     ),
                 ),
-
             );
 
             if(qa_get_logged_in_level() >= QA_USER_LEVEL_MODERATOR){

--- a/forum/qa-plugin/user-activity-log/user-activity-log.php
+++ b/forum/qa-plugin/user-activity-log/user-activity-log.php
@@ -40,11 +40,16 @@
                         'tags'=>'name=condition',
                         'options' => [
                             'username' => qa_lang('user-activity-log/username'),
-                            'ip' => $this->userLevel >= QA_USER_LEVEL_MODERATOR ? qa_lang_html('user-activity-log/ipAdress') : null,
+                            'ip' => qa_lang_html('user-activity-log/ipAdress'),
                             'type' => qa_lang('user-activity-log/eventType'),
                         ],
                         'label' => qa_lang_html('user-activity-log/filters'),
                     ),
+
+                    'date' => array(
+                        'label' => qa_lang_html('user-activity-log/date'),
+                        'tags' => 'placeholder=YYYY-MM-DD name=date value=""',
+                    )
                 ),
 
                 
@@ -58,7 +63,7 @@
                 ),
 
             );
-            $qa_content['navigation']['sub']=qa_admin_sub_navigation();
+            $qa_content['navigation']['sub']= qa_admin_sub_navigation();
             return $qa_content;
         }
     }


### PR DESCRIPTION
Feature z #287 

Dodałem dodatkową podstronę w panelu administracyjnym pozwalającą na wyszukiwanie aktywności użytkowników

Filtrować możemy po nazwie użytkownika, typie aktywności oraz po Adresie IP (od moderatora w górę)
Zaimplementowałem też  (opcjonalny) filtr dat oraz możliwość wyboru ilości wyników, których chcemy uzyskać

Dodatkowo jedynie administratorzy widzą kto głosował lub zgłosił pytanie/komentarz/odpowiedź

Funkcja jest dostępna od redaktora w górę

demo:

admin

https://user-images.githubusercontent.com/69435721/154421980-391b8204-b9a0-423e-b6d1-c7484463bdfb.mp4


redaktor

https://user-images.githubusercontent.com/69435721/154422523-9b400709-e51d-49d0-b482-87900ff4b3bb.mp4


