### PR TITLE
Poprawne wyświetlanie powiadomienia po zamianie odpowiedzi na komentarz

### DIFF
--- a/forum/qa-plugin/q2apro-on-site-notifications/q2apro-history-check.php
+++ b/forum/qa-plugin/q2apro-on-site-notifications/q2apro-history-check.php
@@ -67,7 +67,7 @@ class q2apro_history_check
 
     private function handle_standard_event($event, $loggedUserId, $cookieId, $params)
     {
-        if (strpos($event, 'u_') === 0) {
+        if (strpos($event, 'u_') === 0 && isset($params['userid'])) {
             $eventUserId = $params['userid'];
         } else {
             $eventUserId = qa_db_read_one_value(
@@ -162,7 +162,7 @@ class q2apro_history_check
     {
         if (is_array($value)) {
             $text = 'array(' . count($value) . ')';
-        } elseif (strlen($value) > 40) {
+        } elseif (is_string($value) && strlen($value) > 40) {
             $text = substr($value, 0, 38) . '...';
         } else {
             $text = $value;

--- a/forum/qa-plugin/q2apro-on-site-notifications/q2apro-history-check.php
+++ b/forum/qa-plugin/q2apro-on-site-notifications/q2apro-history-check.php
@@ -53,6 +53,15 @@ class q2apro_history_check
             case 'c_post':
                 $this->handle_answer_comment_create($event, $userid, $cookieid, $params);
                 $this->handle_comments_thread($cookieid, $params);
+                break;
+            case 'a_to_c':
+                qa_db_query_sub(
+                    'DELETE FROM ^eventlog WHERE event="in_a_question" AND params LIKE #',
+                    "postid={$params['postid']}	%"
+                );
+                $this->handle_answer_comment_create('c_post', $userid, $cookieid, $params);
+                $this->handle_comments_thread($cookieid, $params);
+                break;
         }
     }
 

--- a/forum/qa-plugin/q2apro-on-site-notifications/q2apro-history-check.php
+++ b/forum/qa-plugin/q2apro-on-site-notifications/q2apro-history-check.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 	Plugin Name: On-Site-Notifications
 	Plugin URI: http://www.q2apro.com/plugins/on-site-notifications
@@ -10,8 +11,8 @@
 	Plugin License: GPLv3
 	Plugin Minimum Question2Answer Version: → see qa-plugin.php
 	Plugin Update Check URI: https://raw.githubusercontent.com/q2apro/q2apro-on-site-notifications/master/qa-plugin.php
-	
-	This program is free software. You can redistribute and modify it 
+
+	This program is free software. You can redistribute and modify it
 	under the terms of the GNU General Public License.
 
 	This program is distributed in the hope that it will be useful,
@@ -23,182 +24,141 @@
 
 */
 
-	/* The following code originates from q2a plugin "History" by NoahY and has been modified by q2apro.com
-	 * It is licensed under GPLv3 http://www.gnu.org/licenses/gpl.html
-	 * Link to plugin file: https://github.com/NoahY/q2a-history/blob/master/qa-history-check.php
-	 */
+/* The following code originates from q2a plugin "History" by NoahY and has been modified by q2apro.com
+ * It is licensed under GPLv3 http://www.gnu.org/licenses/gpl.html
+ * Link to plugin file: https://github.com/NoahY/q2a-history/blob/master/qa-history-check.php
+ */
 
-	class q2apro_history_check {
-	// main event processing function
-	
-		function process_event($event, $userid, $handle, $cookieid, $params) {
-			
-			if(!qa_opt('event_logger_to_database')) return;
-			
-			// needed for function qa_post_userid_to_handle()
-			require_once QA_INCLUDE_DIR.'qa-app-posts.php';
+class q2apro_history_check
+{
+    function process_event($event, $userid, $handle, $cookieid, $params)
+    {
+        if (!qa_opt('event_logger_to_database')) {
+            return;
+        }
 
-			$twoway = array(
-				'a_select',
-				'q_vote_up',
-				'a_vote_up',
-				'q_vote_down',
-				'a_vote_down',
-				//'a_unselect',
-				//'q_vote_nil',
-				//'a_vote_nil',
-				//'q_flag',
-				//'a_flag',
-				//'c_flag',
-				//'q_unflag',
-				//'a_unflag',
-				//'c_unflag',
-				//'u_edit',
-				//'u_level',
-				//'u_block',
-				//'u_unblock',
-			 );
-			 
-			 $special = array(
-				'a_post',
-				'c_post'
-			);
-			 
-			if(in_array($event, $twoway)) {
-				
-				if(strpos($event,'u_') === 0) {
-					$uid = $params['userid'];
-				}
-				else {
-					$uid = qa_db_read_one_value(
-						qa_db_query_sub(
-							'SELECT userid FROM ^posts WHERE postid=#',
-							$params['postid']
-						),
-						true
-					);
-				}
-				
-				if($uid != $userid) {
-					$ohandle = qa_post_userid_to_handle($uid);
-					
-					$oevent = 'in_'.$event;
-					
-					$paramstring='';
-					
-					foreach ($params as $key => $value) {
-						$paramstring.=(strlen($paramstring) ? "\t" : '').$key.'='.$this->value_to_text($value);						
-					}
-					
-					// write in_ events to qa_eventlog
-					qa_db_query_sub(
-						'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) '.
-						'VALUES (NOW(), $, $, $, #, $, $)',
-						qa_remote_ip_address(), $uid, $ohandle, $cookieid, $oevent, $paramstring
-					);
-				}
-			}
-			
-			// comments and answers
-			if(in_array($event,$special)) {
-				// userid (recent C)
-				$uid = qa_db_read_one_value(
-					qa_db_query_sub(
-						'SELECT userid FROM ^posts WHERE postid=#',
-						$params['postid']
-					),
-					true
-				);
-				// userid (QA)
-				$pid = qa_db_read_one_value(
-					qa_db_query_sub(
-						'SELECT userid FROM ^posts WHERE postid=#',
-						$params['parentid']
-					),
-					true
-				);
-				// if QA poster is not the same as commenter
-				if($pid != $userid) {
-			
-					$ohandle = qa_post_userid_to_handle($pid);
-					
-					switch($event) {
-						case 'a_post':
-								$oevent = 'in_a_question';
-							break;
-						case 'c_post':
-							if ($params['parenttype'] == 'Q')
-								$oevent = 'in_c_question';
-							else 
-								$oevent = 'in_c_answer';
-							break;
-					}
-					
-					$paramstring='';
-					
-					foreach ($params as $key => $value)
-						$paramstring.=(strlen($paramstring) ? "\t" : '').$key.'='.$this->value_to_text($value);
-					
-					qa_db_query_sub(
-						'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) '.
-						'VALUES (NOW(), $, $, $, #, $, $)',
-						qa_remote_ip_address(), $pid, $ohandle, $cookieid, $oevent, $paramstring
-					);				
-				}
-	
-				// q2apro: added logging for comments in thread
-				if($event=='c_post') {
-					$oevent = 'in_c_comment';
+        require_once QA_INCLUDE_DIR . 'qa-app-posts.php';
 
-					// check if we have more comments to the parent
-					// DISTINCT: if a user has more than 1 comment just select him unique to inform him only once
-					$precCommentsQuery = qa_db_query_sub('SELECT DISTINCT userid FROM `^posts`
-												WHERE `parentid` = #
-												AND `type` = "C"
-												AND `userid` IS NOT NULL
-												',
-												$params['parentid']);
+        switch ($event) {
+            case 'a_select':
+            case 'q_vote_up':
+            case 'a_vote_up':
+            case 'q_vote_down':
+            case 'a_vote_down':
+                $this->handle_standard_event($event, $userid, $cookieid, $params);
+                break;
+            case 'a_post':
+                $this->handle_answer_comment_create($event, $userid, $cookieid, $params);
+                break;
+            case 'c_post':
+                $this->handle_answer_comment_create($event, $userid, $cookieid, $params);
+                $this->handle_comments_thread($cookieid, $params);
+        }
+    }
 
-					while( ($comment = qa_db_read_one_assoc($precCommentsQuery,true)) !== null ) {
-						$userid_CommThr = $comment['userid']; // unique
-						
-						// don't inform user that comments, and don't inform user that comments on his own question/answer
-						if($userid_CommThr != $uid && $userid_CommThr != $pid) {
-							$ohandle = qa_post_userid_to_handle($userid_CommThr);
+    private function handle_standard_event($event, $loggedUserId, $cookieId, $params)
+    {
+        if (strpos($event, 'u_') === 0) {
+            $eventUserId = $params['userid'];
+        } else {
+            $eventUserId = qa_db_read_one_value(
+                qa_db_query_sub('SELECT userid FROM ^posts WHERE postid=#', $params['postid']),
+                true
+            );
+        }
 
-							$paramstring = '';
-							foreach ($params as $key => $value) {
-								$paramstring .= (strlen($paramstring) ? "\t" : '').$key.'='.$this->value_to_text($value);
-							}
-							
-							qa_db_query_sub(
-								'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) '.
-								'VALUES (NOW(), $, $, $, #, $, $)',
-								qa_remote_ip_address(), $userid_CommThr, $ohandle, $cookieid, $oevent, $paramstring
-							);
-						}
-					}
-				} // end in_c_comment
-				
-			} // end in_array
-		} // end process_event
+        if ($eventUserId != $loggedUserId) {
+            $postUserHandle = qa_userid_to_handle($eventUserId);
+            $logEvent = 'in_' . $event;
+            $paramString = $this->params_to_string($params);
 
+            qa_db_query_sub(
+                'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) ' .
+                'VALUES (NOW(), $, $, $, #, $, $)',
+                qa_remote_ip_address(), $eventUserId, $postUserHandle, $cookieId, $logEvent, $paramString
+            );
+        }
+    }
 
-		// worker functions
-		function value_to_text($value) {
-			if (is_array($value))
-				$text='array('.count($value).')';
-			elseif (strlen($value)>40)
-				$text=substr($value, 0, 38).'...';
-			else
-				$text=$value;
-				
-			return strtr($text, "\t\n\r", '   ');
-		}
-		
-	} // end class
+    private function handle_answer_comment_create($event, $loggedUserId, $cookieId, $params)
+    {
+        $parentUserId = qa_db_read_one_value(
+            qa_db_query_sub('SELECT userid FROM ^posts WHERE postid=#', $params['parentid']),
+            true
+        );
 
-	
-/*
-	Omit PHP closing tag to help avoid accidental output
-*/
+        if ($parentUserId != $loggedUserId) {
+            $parentUserHandle = qa_userid_to_handle($parentUserId);
+            $paramString = $this->params_to_string($params);
+
+            if ($event === 'a_post') {
+                $logEvent = 'in_a_question';
+            } elseif ($params['parenttype'] === 'Q') {
+                $logEvent = 'in_c_question';
+            } else {
+                $logEvent = 'in_c_answer';
+            }
+
+            qa_db_query_sub(
+                'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) ' .
+                'VALUES (NOW(), $, $, $, #, $, $)',
+                qa_remote_ip_address(), $parentUserId, $parentUserHandle, $cookieId, $logEvent, $paramString
+            );
+        }
+    }
+
+    private function handle_comments_thread($cookieId, $params)
+    {
+        $postUserId = qa_db_read_one_value(
+            qa_db_query_sub('SELECT userid FROM ^posts WHERE postid=#', $params['postid']),
+            true
+        );
+        $parentUserId = qa_db_read_one_value(
+            qa_db_query_sub('SELECT userid FROM ^posts WHERE postid=#', $params['parentid']),
+            true
+        );
+        $paramString = $this->params_to_string($params);
+
+        // DISTINCT: if a user has more than 1 comment just select him unique to inform him only once
+        $commentsQuery = qa_db_query_sub('SELECT DISTINCT userid FROM `^posts` WHERE `parentid` = #
+            AND `type` = "C" AND `userid` IS NOT NULL', $params['parentid']);
+
+        while (($comment = qa_db_read_one_assoc($commentsQuery, true)) !== null) {
+            $commentUserId = $comment['userid'];
+
+            // don't inform user that comments, and don't inform user that comments on his own question/answer
+            if ($commentUserId != $postUserId && $commentUserId != $parentUserId) {
+                $commentUserHandle = qa_userid_to_handle($commentUserId);
+
+                qa_db_query_sub(
+                    'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) ' .
+                    'VALUES (NOW(), $, $, $, #, $, $)',
+                    qa_remote_ip_address(), $commentUserId, $commentUserHandle, $cookieId, 'in_c_comment', $paramString
+                );
+            }
+        }
+    }
+
+    private function params_to_string($params)
+    {
+        $paramString = '';
+        foreach ($params as $key => $value) {
+            $paramString .= (strlen($paramString) ? "\t" : '') . $key . '=' . $this->param_value_to_string($value);
+        }
+
+        return $paramString;
+    }
+
+    private function param_value_to_string($value)
+    {
+        if (is_array($value)) {
+            $text = 'array(' . count($value) . ')';
+        } elseif (strlen($value) > 40) {
+            $text = substr($value, 0, 38) . '...';
+        } else {
+            $text = $value;
+        }
+
+        return strtr($text, "\t\n\r", '   ');
+    }
+}


### PR DESCRIPTION
Zmiana naprawia kwestię powiadomień po zamianie odpowiedzi na komentarz. Do tej pory powiadomienie pozostawało bez zmian - nadal informowało o odpowiedzi i było tylko u osób, które pierwotnie je dostały, np. u autora pytania. W proponowanej zmianie po przeniesieniu odpowiedzi usunie się stare powiadomienie i wygeneruje nowe - z uwzględnieniem tego, że to jest już komentarz i z poprawnymi osobami, które mają je otrzymać.

Fixes #200 
Dodatkowo w pierwszym commicie jest mały refactoring całego pliku.