### PR TITLE
Informacja o dawno zadanym pytaniu

### DIFF
--- a/forum/qa-plugin/outdated-question-info/frontend/css/styles.css
+++ b/forum/qa-plugin/outdated-question-info/frontend/css/styles.css
@@ -1,0 +1,18 @@
+.qa-outdated-question-container{
+    width: 100%;
+
+    text-align: center;
+    padding: 4%;
+
+    border: 6px solid #f74040;
+    margin-bottom: 5%;
+}
+
+.qa-outdated-question-info{
+    padding: 2%;
+    width: 100%;
+
+    
+
+    font-size: 1.5rem;
+}

--- a/forum/qa-plugin/outdated-question-info/frontend/show-outdated-question-info.js
+++ b/forum/qa-plugin/outdated-question-info/frontend/show-outdated-question-info.js
@@ -1,0 +1,16 @@
+
+const placeOfOutdatedQuestionInfo = document.querySelector('.qa-a-form');
+
+const publishDateSpan = document.querySelectorAll('.value-title')[2];
+
+const now = new Date();
+const publishDate = new Date(publishDateSpan.title);
+//TODO: Fix this
+console.log(publishDate.getMonth()-1 >= now.getMonth());
+if(publishDate.getFullYear() < now.getFullYear()) {
+    if(publishDate.getMonth()-2 > now.getMonth()){
+        placeOfOutdatedQuestionInfo.insertAdjacentHTML('beforebegin', `<div><h2>Hello</h2></div>`);
+    }
+}else{
+    placeOfOutdatedQuestionInfo.insertAdjacentHTML('beforebegin', `<div><h2>Bye</h2></div>`);
+}

--- a/forum/qa-plugin/outdated-question-info/frontend/show-outdated-question-info.js
+++ b/forum/qa-plugin/outdated-question-info/frontend/show-outdated-question-info.js
@@ -1,16 +1,30 @@
+const showInfoAboutOutdatedQuestion = (placeOfOutdatedQuestionInfo) => {
+    const publishDateSpan = document.querySelectorAll('.value-title')[2];
 
-const placeOfOutdatedQuestionInfo = document.querySelector('.qa-a-form');
+    const now = new Date();
+    const publishDate = new Date(publishDateSpan.title);
 
-const publishDateSpan = document.querySelectorAll('.value-title')[2];
-
-const now = new Date();
-const publishDate = new Date(publishDateSpan.title);
-//TODO: Fix this
-console.log(publishDate.getMonth()-1 >= now.getMonth());
-if(publishDate.getFullYear() < now.getFullYear()) {
-    if(publishDate.getMonth()-2 > now.getMonth()){
-        placeOfOutdatedQuestionInfo.insertAdjacentHTML('beforebegin', `<div><h2>Hello</h2></div>`);
+    if(publishDate.getFullYear() < now.getFullYear()) {
+        if(publishDate.getMonth()-1 >= now.getMonth()){
+            if(!document.querySelector('.qa-outdated-question')) {
+                placeOfOutdatedQuestionInfo.insertAdjacentHTML('beforebegin', 
+                        `<div class = "qa-outdated-question-container">
+                                <span class = "qa-outdated-question-info">
+                                        To pytanie zostało zadane ponad 2 miesiące temu i może być już nie aktualne.<br/>
+                                        Zastanów się, czy na pewno chcesz "odkopać" to pytanie.
+                                </span>
+                        </div>`);
+            }
+        }
     }
-}else{
-    placeOfOutdatedQuestionInfo.insertAdjacentHTML('beforebegin', `<div><h2>Bye</h2></div>`);
+}
+if(document.querySelector('.qa-a-form')!== null){
+    const placeOfOutdatedQuestionInfo = document.querySelector('.qa-a-form')
+    if(placeOfOutdatedQuestionInfo.getAttribute('style') === "display:none;"){
+        document.querySelector('#q_doanswer').addEventListener('click', ()=>{
+            showInfoAboutOutdatedQuestion(placeOfOutdatedQuestionInfo)
+        });
+    }else{
+        showInfoAboutOutdatedQuestion(placeOfOutdatedQuestionInfo);
+    }
 }

--- a/forum/qa-plugin/outdated-question-info/qa-outdated-question-info-layer.php
+++ b/forum/qa-plugin/outdated-question-info/qa-outdated-question-info-layer.php
@@ -4,6 +4,9 @@ class qa_html_theme_layer extends qa_html_theme_base
 {
     public function head_script(){
         parent::head_script();
-        $this->output('<script src = "'. QA_HTML_THEME_LAYER_URLTOROOT .'frontend/show-outdated-question-info.js?v=" defer></script>');
+        $this->output('
+            <script src = "'. QA_HTML_THEME_LAYER_URLTOROOT .'frontend/show-outdated-question-info.js?v=" defer></script>
+            <link rel = "stylesheet" href = "'. QA_HTML_THEME_LAYER_URLTOROOT .'frontend/css/styles.css?v=" />
+        ');
     }
 }

--- a/forum/qa-plugin/outdated-question-info/qa-outdated-question-info-layer.php
+++ b/forum/qa-plugin/outdated-question-info/qa-outdated-question-info-layer.php
@@ -1,0 +1,9 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+    public function head_script(){
+        parent::head_script();
+        $this->output('<script src = "'. QA_HTML_THEME_LAYER_URLTOROOT .'frontend/show-outdated-question-info.js?v=" defer></script>');
+    }
+}

--- a/forum/qa-plugin/outdated-question-info/qa-plugin.php
+++ b/forum/qa-plugin/outdated-question-info/qa-plugin.php
@@ -1,0 +1,9 @@
+<?php
+
+//Don't let this page to be available directly from browser
+if (!defined('QA_VERSION')) {
+    header('Location: ../../');
+    exit;
+}
+
+qa_register_plugin_layer('qa-outdated-question-info-layer.php', 'Outdated Question Info');


### PR DESCRIPTION
Ta zmiana jest z issue #293 
Dodałem prostą informację otoczoną czerwoną ramką. Pojawia się gdy użytkownik otworzy za pomocą przycisku formularz odpowiedzi, a przy pytaniach bez odpowiedzi, po prostu domyślnie się pokazuje

Kwestią do ustalenia może być jeszcze kolor ramki, oraz treść informacji

A tak  prezentuje się ramka

Jasny Motyw:


![pr - Outdated-Question1](https://user-images.githubusercontent.com/69435721/163198581-8686efa4-c5a2-43c0-98a5-fdcb06e6f74c.jpg)

Ciemny Motyw:

![obraz](https://user-images.githubusercontent.com/69435721/163198702-b91488bb-f872-4a23-adb1-ea20cf63ee6a.png)



