### PR TITLE
Poziome rozszerzanie bloczka z kodem po najechaniu myszką

### DIFF
--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -1473,6 +1473,11 @@ const codeBlockInteractiveBar = () => {
                         this.#collapsibleToggleBtn.disabled = true;
                         this.#horizontallyExtendedCodeBlock = target;
                         this.#toggleRootsOverflowing(target, true);
+                        /*
+                            make sure roots overflow is still "active" to avoid possible race condition 
+                            with other collapsing code block, which may turn roots overflow off
+                        */
+                        target.addEventListener('transitionend', () => this.#toggleRootsOverflowing(target, true), { once: true });
 
                         const qaMainWrapperWidth = window.getComputedStyle(this.#overflowingRoots[0]).width;
                         const qaMainWrapperOffsetLeft = this.#overflowingRoots[0].getBoundingClientRect().left;

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -1460,8 +1460,12 @@ const codeBlockInteractiveBar = () => {
             #extendCodeBlock({ target }) {
                 const isCodeBlock = target.classList.contains('syntaxhighlighter');
                 const isCodeBlockCollapsed = target.classList.contains('collapsed-block');
+                const scrollOffset = target.clientWidth < target.scrollWidth ? (target.scrollWidth - target.clientWidth) : 0;
 
-                if (isCodeBlock && !isCodeBlockCollapsed && !this.#checkIfFullScreenIsActive()) {
+                if (
+                    isCodeBlock && scrollOffset && !isCodeBlockCollapsed && 
+                    this.#collapsibleToggleBtn && !this.#checkIfFullScreenIsActive()
+                ) {
                     if (this.#horizontallyExtendedCodeBlock) {
                         // prepare re-hover
                         this.#abortController?.abort();
@@ -1479,12 +1483,15 @@ const codeBlockInteractiveBar = () => {
                         */
                         target.addEventListener('transitionend', () => this.#toggleRootsOverflowing(target, true), { once: true });
 
-                        const qaMainWrapperWidth = window.getComputedStyle(this.#overflowingRoots[0]).width;
+                        const qaMainWrapperWidth = Number.parseInt(window.getComputedStyle(this.#overflowingRoots[0]).width);
                         const qaMainWrapperOffsetLeft = this.#overflowingRoots[0].getBoundingClientRect().left;
                         const offsetToQaBodyWrapper = Math.abs(qaMainWrapperOffsetLeft - target.getBoundingClientRect().left);
+                        const targetOutputWidth = Math.min(target.scrollWidth, qaMainWrapperWidth);
+                        const targetOutputLeft = Math.min(scrollOffset / 2, offsetToQaBodyWrapper);
 
-                        target.style.setProperty('--extended-horizontal-width', qaMainWrapperWidth);
-                        target.style.setProperty('--offset-to-qa-body-wrapper', offsetToQaBodyWrapper);
+                        target.style.setProperty('--extended-horizontal-width', `${targetOutputWidth}px`);
+                        target.style.setProperty('--max-extended-horizontal-width', `${qaMainWrapperWidth}px`);
+                        target.style.setProperty('--offset-to-qa-body-wrapper', targetOutputLeft);
                         target.classList.add('syntaxhighlighter--horizontally-extended');
                         target.previousElementSibling.classList.add('syntaxhighlighter-block-bar--horizontally-extensible');
                     }

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -1466,7 +1466,11 @@ const codeBlockInteractiveBar = () => {
                     this.#toggleRootsOverflowing(target, true);
 
                     const qaMainWrapperWidth = window.getComputedStyle(this.#overflowingRoots[0]).width;
+                    const qaMainWrapperOffsetLeft = this.#overflowingRoots[0].getBoundingClientRect().left;
+                    const offsetToQaBodyWrapper = Math.abs(qaMainWrapperOffsetLeft - target.getBoundingClientRect().left);
+
                     target.style.setProperty('--extended-horizontal-width', qaMainWrapperWidth);
+                    target.style.setProperty('--offset-to-qa-body-wrapper', offsetToQaBodyWrapper);
                     target.classList.add('syntaxhighlighter--horizontally-extended');
                 }
             }

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -1486,6 +1486,7 @@ const codeBlockInteractiveBar = () => {
                         target.style.setProperty('--extended-horizontal-width', qaMainWrapperWidth);
                         target.style.setProperty('--offset-to-qa-body-wrapper', offsetToQaBodyWrapper);
                         target.classList.add('syntaxhighlighter--horizontally-extended');
+                        target.previousElementSibling.classList.add('syntaxhighlighter-block-bar--horizontally-extensible');
                     }
                 }
             }
@@ -1500,6 +1501,7 @@ const codeBlockInteractiveBar = () => {
                         this.#abortController = null;
                     }
                     this.#horizontallyExtendedCodeBlock.classList.remove('syntaxhighlighter--horizontally-extended');
+                    this.#horizontallyExtendedCodeBlock.previousElementSibling.classList.remove('syntaxhighlighter-block-bar--horizontally-extensible');
 
                     target.addEventListener('transitionend', () => {
                         this.#toggleRootsOverflowing(target, false);

--- a/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
+++ b/forum/qa-plugin/ckeditor4/plugins/syntaxhighlight/init.js
@@ -1477,9 +1477,8 @@ const codeBlockInteractiveBar = () => {
 
             #collapseCodeBlock({ target }) {
                 const isSyntaxHighlighterParent = target.classList.contains('syntaxhighlighter-parent');
-                const horizontallyExtendedCodeBlock = target.querySelector('.syntaxhighlighter--horizontally-extended');
 
-                if (isSyntaxHighlighterParent && horizontallyExtendedCodeBlock) {
+                if (isSyntaxHighlighterParent && this.#horizontallyExtendedCodeBlock) {
                     this.#horizontallyExtendedCodeBlock.classList.remove('syntaxhighlighter--horizontally-extended');
 
                     target.addEventListener('transitionend', () => {

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4689,12 +4689,13 @@ pre[class*="brush:"]
 .syntaxhighlighter
 {
 	max-height: var(--code-block-raw-height); /* provided by inline style from JavaScript */
-	--syntaxhighlighter-collapsible-transition: max-height 0.2s ease-in-out;
+	--transition-timing-and-effect: 0.2s ease-in-out;
+	--syntaxhighlighter-collapsible-transition: max-height var(--transition-timing-and-effect);
 	transition: 
 		var(--syntaxhighlighter-collapsible-transition), 
-		transform 0.2s ease-in-out, 
-		width 0.2s ease-in-out;
-	z-index: 1;
+		transform var(--transition-timing-and-effect), 
+		width var(--transition-timing-and-effect),
+		border var(--transition-timing-and-effect);
 }
 
 .syntaxhighlighter-parent .syntaxhighlighter .toolbar
@@ -4780,14 +4781,61 @@ pre[class*="brush:"]::after
 	opacity: 1;
 	transition: opacity 0.2s;
 	border-radius: 50px 50px 1px 1px;
-	position: relative;
-	z-index: 2;
 
 	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#3498db+0,3498db+50,3498db+100&0.75+0,1+50,0.75+100 */
 	background: -moz-linear-gradient(left,  rgba(52,152,219,0.45) 0%, rgba(52,152,219,0.75) 50%, rgba(52,152,219,0.45) 100%); /* FF3.6-15 */
 	background: -webkit-linear-gradient(left,  rgba(52,152,219,0.45) 0%,rgba(52,152,219,0.75) 50%,rgba(52,152,219,0.45) 100%); /* Chrome10-25,Safari5.1-6 */
 	background: linear-gradient(to right,  rgba(52,152,219,0.45) 0%,rgba(52,152,219,0.75) 50%,rgba(52,152,219,0.45) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#bf3498db', endColorstr='#bf3498db',GradientType=1 ); /* IE6-9 */
+}
+
+.syntaxhighlighter-block-bar--horizontally-extensible {
+	position: relative;
+	z-index: 2;
+}
+
+.syntaxhighlighter-block-bar--horizontally-extensible::before, 
+.syntaxhighlighter-block-bar--horizontally-extensible::after {
+    content: '';
+    position: absolute;
+    bottom: 0px;
+    background: inherit;
+    height: 5px;
+    width: 100%;
+}
+
+.syntaxhighlighter-block-bar--horizontally-extensible::before {
+	left: -100%;
+	animation: extendBlockBarLeftArm 0.5s ease-in-out;
+}
+
+.syntaxhighlighter-block-bar--horizontally-extensible::after {
+	right: -100%;
+	animation: extendBlockBarRightArm 0.3s ease-in-out;
+}
+
+@keyframes extendBlockBarLeftArm {
+	from {
+		width: 0;
+		left: 0;
+	}
+	
+	to {
+		width: 100%;
+		left: -100%;
+	}
+}
+
+@keyframes extendBlockBarRightArm {
+	from {
+		width: 0;
+		right: 0;
+	}
+	
+	to {
+		width: 100%;
+		right: -100%;
+	}
 }
 
 .features-drawer__button {
@@ -5296,6 +5344,9 @@ ul.features-drawer-list--hidden
 			) * -1px
 		)
 	);
+	border: 5px solid rgba(52,152,219,0.75);
+	border-top: none;
+	z-index: 1;
 }
 
 /* End of Interactive Code Block Bar */

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -5286,15 +5286,13 @@ ul.features-drawer-list--hidden
 .syntaxhighlighter.syntaxhighlighter--horizontally-extended {
 	/* override SyntaxHighlighter `!important` rule */
 	width: var(--extended-horizontal-width, max-content) !important;
-	--qa-body-wrapper-margin-side: 130;
-	/* restrict to `.qa-body-wrapper` margin */
+	--qa-body-wrapper-margin-inline: 130;
 	max-width: var(--offset-to-qa-body-wrapper, 100%);
 	transform: translateX(
 		calc(
 			var(
 				--offset-to-qa-body-wrapper, 
-				/* fallback to `.qa-body-wrapper` margin */
-				var(--qa-body-wrapper-margin-side)
+				var(--qa-body-wrapper-margin-inline)
 			) * -1px
 		)
 	);

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4694,8 +4694,9 @@ pre[class*="brush:"]
 	transition: 
 		var(--syntaxhighlighter-collapsible-transition), 
 		transform var(--transition-timing-and-effect), 
-		width var(--transition-timing-and-effect),
-		border var(--transition-timing-and-effect);
+		width var(--transition-timing-and-effect);
+	position: relative;
+	z-index: 1;
 }
 
 .syntaxhighlighter-parent .syntaxhighlighter .toolbar
@@ -4787,55 +4788,9 @@ pre[class*="brush:"]::after
 	background: -webkit-linear-gradient(left,  rgba(52,152,219,0.45) 0%,rgba(52,152,219,0.75) 50%,rgba(52,152,219,0.45) 100%); /* Chrome10-25,Safari5.1-6 */
 	background: linear-gradient(to right,  rgba(52,152,219,0.45) 0%,rgba(52,152,219,0.75) 50%,rgba(52,152,219,0.45) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#bf3498db', endColorstr='#bf3498db',GradientType=1 ); /* IE6-9 */
-}
 
-.syntaxhighlighter-block-bar--horizontally-extensible {
 	position: relative;
 	z-index: 2;
-}
-
-.syntaxhighlighter-block-bar--horizontally-extensible::before, 
-.syntaxhighlighter-block-bar--horizontally-extensible::after {
-    content: '';
-    position: absolute;
-    bottom: 0px;
-    background: inherit;
-    height: 5px;
-    width: 100%;
-}
-
-.syntaxhighlighter-block-bar--horizontally-extensible::before {
-	left: -100%;
-	animation: extendBlockBarLeftArm 0.5s ease-in-out;
-}
-
-.syntaxhighlighter-block-bar--horizontally-extensible::after {
-	right: -100%;
-	animation: extendBlockBarRightArm 0.3s ease-in-out;
-}
-
-@keyframes extendBlockBarLeftArm {
-	from {
-		width: 0;
-		left: 0;
-	}
-	
-	to {
-		width: 100%;
-		left: -100%;
-	}
-}
-
-@keyframes extendBlockBarRightArm {
-	from {
-		width: 0;
-		right: 0;
-	}
-	
-	to {
-		width: 100%;
-		right: -100%;
-	}
 }
 
 .features-drawer__button {
@@ -5335,7 +5290,7 @@ ul.features-drawer-list--hidden
 	/* override SyntaxHighlighter `!important` rule */
 	width: var(--extended-horizontal-width, max-content) !important;
 	--qa-body-wrapper-margin-inline: 130;
-	max-width: var(--offset-to-qa-body-wrapper, 100%);
+	max-width: var(--max-extended-horizontal-width, 100%);
 	transform: translateX(
 		calc(
 			var(
@@ -5344,9 +5299,9 @@ ul.features-drawer-list--hidden
 			) * -1px
 		)
 	);
-	border: 5px solid rgba(52,152,219,0.75);
+	outline: 2px solid rgba(52,152,219,0.75);
+	border-inline: 2px solid rgba(52,152,219,0.75);
 	border-top: none;
-	z-index: 1;
 }
 
 /* End of Interactive Code Block Bar */

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4690,7 +4690,12 @@ pre[class*="brush:"]
 {
 	max-height: var(--code-block-raw-height); /* provided by inline style from JavaScript */
 	--syntaxhighlighter-collapsible-transition: max-height 0.2s ease-in-out;
-	transition: var(--syntaxhighlighter-collapsible-transition);
+	transition: 
+		var(--syntaxhighlighter-collapsible-transition), 
+		left 0.2s ease-in-out, 
+		width 0.2s ease-in-out;
+	left: 0;
+	z-index: 1;
 }
 
 .syntaxhighlighter-parent .syntaxhighlighter .toolbar
@@ -4776,6 +4781,8 @@ pre[class*="brush:"]::after
 	opacity: 1;
 	transition: opacity 0.2s;
 	border-radius: 50px 50px 1px 1px;
+	position: relative;
+	z-index: 2;
 
 	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#3498db+0,3498db+50,3498db+100&0.75+0,1+50,0.75+100 */
 	background: -moz-linear-gradient(left,  rgba(52,152,219,0.45) 0%, rgba(52,152,219,0.75) 50%, rgba(52,152,219,0.45) 100%); /* FF3.6-15 */
@@ -5275,6 +5282,15 @@ ul.features-drawer-list--hidden
 	.syntaxhighlighter-block-bar:not(.is-collapsible) .features-drawer-list {
 		right: -22px;
 	}
+}
+
+.syntaxhighlighter.syntaxhighlighter--horizontally-extended {
+	/* override SyntaxHighlighter `!important` rule */
+	width: var(--extended-horizontal-width, max-content) !important;
+	--qa-body-wrapper-margin-side: 130;
+	/* restrict to `.qa-body-wrapper` margin */
+	max-width: calc(95vw - calc(var(--qa-body-wrapper-margin-side) * 2px));
+	left: calc(var(--qa-body-wrapper-margin-side) * -1px);
 }
 
 /* End of Interactive Code Block Bar */

--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -4692,9 +4692,8 @@ pre[class*="brush:"]
 	--syntaxhighlighter-collapsible-transition: max-height 0.2s ease-in-out;
 	transition: 
 		var(--syntaxhighlighter-collapsible-transition), 
-		left 0.2s ease-in-out, 
+		transform 0.2s ease-in-out, 
 		width 0.2s ease-in-out;
-	left: 0;
 	z-index: 1;
 }
 
@@ -5289,8 +5288,16 @@ ul.features-drawer-list--hidden
 	width: var(--extended-horizontal-width, max-content) !important;
 	--qa-body-wrapper-margin-side: 130;
 	/* restrict to `.qa-body-wrapper` margin */
-	max-width: calc(95vw - calc(var(--qa-body-wrapper-margin-side) * 2px));
-	left: calc(var(--qa-body-wrapper-margin-side) * -1px);
+	max-width: var(--offset-to-qa-body-wrapper, 100%);
+	transform: translateX(
+		calc(
+			var(
+				--offset-to-qa-body-wrapper, 
+				/* fallback to `.qa-body-wrapper` margin */
+				var(--qa-body-wrapper-margin-side)
+			) * -1px
+		)
+	);
 }
 
 /* End of Interactive Code Block Bar */


### PR DESCRIPTION
Inspiracja na pomysł pochodzi od @Argeento, który jakiś czas temu dodawał ten ficzer do nowego (testowego) forum.

Generalnie mamy już możliwość [przeglądania bloczka z kodem na pełnym ekranie](https://github.com/CodersCommunity/forum.pasja-informatyki.local/pull/270). Natomiast często przydaje się przejrzeć kod w możliwie najszerszym widoku, nie chcąc jednak specjalnie wchodzić we wspomniany tryb. Pomyślałem, że przyda się więc taka funkcjonalność, która aktywuje się w momencie najechania myszką na rozwinięty bloczek.

Poniżej filmik jak to działa.

https://user-images.githubusercontent.com/18393526/193429195-93fe3cba-2046-4546-87bd-b4ccb32e4c57.mp4