### PR TITLE
Discord notifications plugin - powiadomienia o nowych pytaniach

### DIFF
--- a/forum/qa-plugin/q2a-discord-notifications/README.md
+++ b/forum/qa-plugin/q2a-discord-notifications/README.md
@@ -1,0 +1,3 @@
+# Q2A Discord notifications
+
+Notifications about new questions to Discord channels

--- a/forum/qa-plugin/q2a-discord-notifications/lang/default.php
+++ b/forum/qa-plugin/q2a-discord-notifications/lang/default.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'message' => 'New question added:',
+    'author' => 'Author',
+    'category' => 'Category',
+    'tags' => 'Tags',
+
+    'admin_ok_info' => 'Saved',
+    'admin_save_button' => 'Save',
+    'admin_config_label' => 'Configuration JSON ("category id": "webhook url")',
+];

--- a/forum/qa-plugin/q2a-discord-notifications/lang/pl.php
+++ b/forum/qa-plugin/q2a-discord-notifications/lang/pl.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'message' => 'Na forum zostało zadane nowe pytanie:',
+    'author' => 'Autor',
+    'category' => 'Kategoria',
+    'tags' => 'Tagi',
+
+    'admin_ok_info' => 'Zapisano',
+    'admin_save_button' => 'Zapisz',
+    'admin_config_label' => 'JSON konfiguracyjny ("id kategorii": "webhook url")',
+];

--- a/forum/qa-plugin/q2a-discord-notifications/metadata.json
+++ b/forum/qa-plugin/q2a-discord-notifications/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "Discord notifications",
+  "uri": "",
+  "description": "Notifications about new questions to Discord channels",
+  "version": "1.0.0",
+  "date": "2022-10-07",
+  "author": "Arkadiusz Waluk",
+  "author_uri": "https://waluk.pl",
+  "license": "",
+  "update_uri": "",
+  "min_q2a": "1.7",
+  "min_php": "7.0"
+}

--- a/forum/qa-plugin/q2a-discord-notifications/qa-plugin.php
+++ b/forum/qa-plugin/q2a-discord-notifications/qa-plugin.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+    Plugin Name: Discord notifications
+    Plugin URI:
+    Plugin Description: Notifications about new questions to Discord channels
+    Plugin Version: 1.0.0
+    Plugin Date: 2022-10-07
+    Plugin Author: Arkadiusz Waluk
+    Plugin Author URI: https://waluk.pl
+    Plugin License: MIT
+    Plugin Minimum Question2Answer Version: 1.7
+    Plugin Minimum PHP Version: 7.0
+    Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) {
+    header('Location: ../../');
+    exit();
+}
+
+qa_register_plugin_module('event', 'src/discord-notifications-event.php', 'discord_notifications_event', 'Discord notifications event');
+qa_register_plugin_module('admin', 'src/discord-notifications-admin.php', 'discord_notifications_admin', 'Discord notifications admin');
+qa_register_plugin_phrases('lang/*.php', 'discord_notifications');

--- a/forum/qa-plugin/q2a-discord-notifications/src/discord-notifications-admin.php
+++ b/forum/qa-plugin/q2a-discord-notifications/src/discord-notifications-admin.php
@@ -1,0 +1,33 @@
+<?php
+
+class discord_notifications_admin
+{
+    public function admin_form()
+    {
+        $saved = false;
+        if (qa_clicked('save')) {
+            $config = qa_post_text('config');
+            qa_opt('discord_notifications_config', $config);
+            $saved = true;
+        }
+
+        return [
+            'ok' => $saved ? qa_lang('discord_notifications/admin_ok_info') : null,
+            'fields' => [
+                [
+                    'type' => 'textarea',
+                    'label' => qa_lang('discord_notifications/admin_config_label'),
+                    'value' => qa_html(qa_opt('discord_notifications_config')),
+                    'tags' => 'name="config"',
+                    'rows' => 5
+                ],
+            ],
+            'buttons' => [
+                [
+                    'label' => qa_lang('discord_notifications/admin_save_button'),
+                    'tags' => 'name="save"'
+                ]
+            ]
+        ];
+    }
+}

--- a/forum/qa-plugin/q2a-discord-notifications/src/discord-notifications-event.php
+++ b/forum/qa-plugin/q2a-discord-notifications/src/discord-notifications-event.php
@@ -1,0 +1,77 @@
+<?php
+
+class discord_notifications_event
+{
+    public function process_event($event, $userid, $handle, $cookieid, $params)
+    {
+        if ($event !== 'q_post' || empty(qa_opt('discord_notifications_config'))) {
+            return;
+        }
+
+        $webhook = $this->get_webhook_url($params['categoryid']);
+        if (empty($webhook)) {
+            return;
+        }
+
+        $body = $this->prepare_body($handle, $params);
+        $this->send_to_webhook($webhook, $body);
+    }
+
+    private function get_webhook_url(int $category)
+    {
+        $config = json_decode(qa_opt('discord_notifications_config'), true);
+        if (isset($config[$category])) {
+            return $config[$category];
+        }
+
+        return null;
+    }
+
+    private function prepare_body(string $username, array $params)
+    {
+        $category = qa_db_read_one_value(
+            qa_db_query_sub('SELECT title FROM ^categories WHERE categoryid = $', $params['categoryid'])
+        );
+        $content = str_replace(["\r", "\n"], ' ', $params['text']);
+
+        return [
+            'content' => qa_lang('discord_notifications/message'),
+            'embeds' => [
+                [
+                    'title' => $params['title'],
+                    'url' => qa_q_path_html($params['postid'], $params['title'], true),
+                    'description' => mb_strimwidth($content, 0, 200, "..."),
+                    'fields' => [
+                        [
+                            'name' => qa_lang('discord_notifications/author'),
+                            'value' => $username,
+                            'inline' => true
+                        ],
+                        [
+                            'name' => qa_lang('discord_notifications/category'),
+                            'value' => $category,
+                            'inline' => true
+                        ],
+                        [
+                            'name' => qa_lang('discord_notifications/tags'),
+                            'value' => str_replace(',', ', ', $params['tags']),
+                            'inline' => true
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    private function send_to_webhook(string $url, array $body)
+    {
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_URL, $url);
+        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'POST');
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($body));
+        curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+        curl_exec($curl);
+        curl_close($curl);
+    }
+}


### PR DESCRIPTION
Taka propozycja już kiedyś padała i pomyślałem, że spróbuję ją przygotować, może się przyjmie. Chodzi o to, aby po dodaniu nowego pytania na forum informacja wpadała na Discorda, aby osoby siedzące głównie tam zachęcić do zerknięcia na dany temat na forum :)

Jest to zrobione przez webhook, a konkretnie dla każdej kategorii można ustawić inny webhook. Dzięki temu pytania z różnych kategorii będę mogły trafiać na tematyczne kanały na Discordzie (lub nie trafiać wcale jeśli się dla danej kategorii nie ustawi). Konfiguracja w panelu w jsonie może nie jest najwygodniejsza, ale jest najprostsza do wykonania, a to się pewnie raz ustawi i zapomni, więc wg mnie może być. Wysyłana jest krótka wiadomość z embedem, który zawiera tytuł pytania, początek treści, nick autora, kategorię oraz tagi.

Minus publikacji przez webhook jest taki, że w razie edycji czy usunięcia pytania, na Discordzie wiadomość nadal pozostanie. Aby zrobić usuwanie czy edytowanie tych wiadomości trzeba byłoby się pewnie pobawić w bota, który by tego wszystkiego pilnował, a nie wiem czy do tak prostego celu to ma sens.

Przykładowa wiadomość, która dotrze na Discorda:
![Zrzut ekranu z 2022-10-08 23-41-44](https://user-images.githubusercontent.com/13801608/194728700-2063e1f9-6c15-41ee-923d-99a662fa0e0b.png)
