### PR TITLE
Przekierowanie pytania na pełny adres

### DIFF
--- a/forum/qa-include/pages/question.php
+++ b/forum/qa-include/pages/question.php
@@ -82,6 +82,15 @@
 	if (!isset($question))
 		return include QA_INCLUDE_DIR.'qa-page-not-found.php';
 
+	$validurl = qa_q_request($question['postid'], $question['title']);
+	if (qa_request() !== $validurl) {
+		$pagestart = qa_get_start();
+		$url = qa_path_html($validurl, !empty($pagestart) ? ['start' => $pagestart] : null, qa_opt('site_url'));
+		qa_redirect_raw($url);
+
+		return;
+	}
+
 	if (!$question['viewable']) {
 		$qa_content=qa_content_prepare();
 

--- a/forum/qa-include/pages/question.php
+++ b/forum/qa-include/pages/question.php
@@ -86,6 +86,8 @@
 	if (qa_request() !== $validurl) {
 		$pagestart = qa_get_start();
 		$url = qa_path_html($validurl, !empty($pagestart) ? ['start' => $pagestart] : null, qa_opt('site_url'));
+
+		header('HTTP/1.1 301 Moved Permanently');
 		qa_redirect_raw($url);
 
 		return;


### PR DESCRIPTION
Poprawka, która dodaje przekierowanie na właściwy adres pytania. Obecnie można w adresie wpisać w zasadzie cokolwiek, zgadzać się musi tylko id, i działa. Jest wtedy co prawda meta canonical, ale zdaje się, że skuteczniejszą formą, aby takie linki w ogóle nie miały okazji być gdzieś propagowane, będzie przekierowanie 301 od razu na właściwy adres. Problemu żadnego być nie powinno, bo jeśli gdzieś do tej pory coś było źle zaindeksowane to powinno się zmienić na właściwy adres, a jeśli ktoś lubił możliwość wejścia poprzez samo wpisanie domena/id pytania, to nadal będzie to działało tylko od razu z przekierowaniem na właściwy adres.