### PR TITLE
Dodanie meta og do strony

### DIFF
--- a/forum/qa-plugin/q2a-og-metas/lang/default.php
+++ b/forum/qa-plugin/q2a-og-metas/lang/default.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'admin_saved_info' => 'Saved',
+    'admin_image_url_label' => 'URL for og:image meta',
+    'admin_save_button' => 'Save',
+];

--- a/forum/qa-plugin/q2a-og-metas/lang/pl.php
+++ b/forum/qa-plugin/q2a-og-metas/lang/pl.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'admin_saved_info' => 'Zapisano',
+    'admin_image_url_label' => 'URL do meta og:image',
+    'admin_save_button' => 'Zapisz',
+];

--- a/forum/qa-plugin/q2a-og-metas/metadata.json
+++ b/forum/qa-plugin/q2a-og-metas/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "OG Metas",
+  "uri": "",
+  "description": "Add OG meta tags",
+  "version": "1.0.0",
+  "date": "2022-10-26",
+  "author": "Arkadiusz Waluk",
+  "author_uri": "https://waluk.pl",
+  "license": "",
+  "update_uri": "",
+  "min_q2a": "1.7",
+  "min_php": "7.0"
+}

--- a/forum/qa-plugin/q2a-og-metas/qa-plugin.php
+++ b/forum/qa-plugin/q2a-og-metas/qa-plugin.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+    Plugin Name: OG Metas
+    Plugin URI:
+    Plugin Description: Add OG meta tags
+    Plugin Version: 1.0.0
+    Plugin Date: 2022-10-26
+    Plugin Author: Arkadiusz Waluk
+    Plugin Author URI: https://waluk.pl
+    Plugin License:
+    Plugin Minimum Question2Answer Version: 1.7
+    Plugin Minimum PHP Version: 7.0
+    Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) {
+    header('Location: ../../');
+    exit();
+}
+
+qa_register_plugin_layer('src/og-metas-layer.php', 'OG Metas layer');
+qa_register_plugin_module('module', 'src/og-metas-admin.php', 'og_metas_admin', 'OG Metas admin');
+qa_register_plugin_phrases('lang/*.php', 'og_metas');

--- a/forum/qa-plugin/q2a-og-metas/src/og-metas-admin.php
+++ b/forum/qa-plugin/q2a-og-metas/src/og-metas-admin.php
@@ -1,0 +1,30 @@
+<?php
+
+class og_metas_admin
+{
+    public function admin_form()
+    {
+        $saved = qa_clicked('og_metas_save');
+        if ($saved) {
+            qa_opt('og_metas_image_url', qa_post_text('og_metas_image_url'));
+        }
+
+        return [
+            'ok' => $saved ? qa_lang_html('og_metas/admin_saved_info') : null,
+            'fields' => [
+                [
+                    'label' => qa_lang_html('og_metas/admin_image_url_label'),
+                    'type' => 'text',
+                    'value' => qa_opt('og_metas_image_url'),
+                    'tags' => 'name="og_metas_image_url"',
+                ],
+            ],
+            'buttons' => [
+                [
+                    'label' => qa_lang_html('og_metas/admin_save_button'),
+                    'tags' => 'name="og_metas_save"'
+                ],
+            ]
+        ];
+    }
+}

--- a/forum/qa-plugin/q2a-og-metas/src/og-metas-layer.php
+++ b/forum/qa-plugin/q2a-og-metas/src/og-metas-layer.php
@@ -1,0 +1,31 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+    public function head_metas()
+    {
+        $siteTitle = $this->content['site_title'] ?? '';
+        $pageTitle = !empty($this->request) ? strip_tags($this->content['title'] ?? '') : '';
+        $title = (!empty($pageTitle) ? ($pageTitle . ' - ') : '') . $siteTitle;
+
+        $metas = [
+            'og:url' => $this->content['canonical'] ?? qa_path_absolute($this->request),
+            'og:site_name' => $siteTitle,
+            'og:title' => $title,
+            'og:description' => $this->content['description'] ?? '',
+            'og:image' => qa_opt('og_metas_image_url'),
+            'og:type' => 'website',
+            'twitter:card' => 'summary',
+        ];
+
+        foreach ($metas as $property => $content) {
+            if (empty($property) || empty($content)) {
+                continue;
+            }
+
+            $this->output(sprintf('<meta property="%s" content="%s">', $property, $content));
+        }
+
+        parent::head_metas();
+    }
+}


### PR DESCRIPTION
Obecnie nie posiadaliśmy wcale dodanych tagów meta og, dzięki którym np. Facebook czy Twitter mógłby wyświetlić ładne podglądy naszych linków. Ten plugin dodaje najbardziej podstawowe tagi z możliwością konfiguracji URL do obrazka z poziomu panelu. Tytuł i opis wstawia tak samo jak generowany jest do klasycznych meta tagów już dodawanych przez Q2A.

Przetestowane na Facebooku i Twitterze - tam działa. Jakiś problem jest z Discordem, z tego co czytałem też powinien bazować na tych tagach, niestety pomimo różnych prób nadal nie ładuje podglądów. Nie wiem czy to jakiś głębszy problem czy po prostu brakuje mu jakiegoś taga, pomimo różnych kombinacji nie udało mi się tego uzyskać, może ktoś ma jeszcze jakiś pomysł, a jeśli nie to na razie chociaż tyle.