### PR TITLE
Poprawka rozciągania zdjęć dodanych przez CKEditora

### DIFF
--- a/forum/qa-theme/SnowFlat/qa-styles.css
+++ b/forum/qa-theme/SnowFlat/qa-styles.css
@@ -1061,6 +1061,9 @@ h1 a:hover, h1 a:focus, h1 a:visited {
 .entry-content ol > li > ol, .qa-c-item-content ol > li > ol {
 	margin: 0 0 0 20px;
 }
+.entry-content img { /* we need to override inline styles from CKEditor */
+	height: auto !important;
+}
 
 .qa-waiting {
 	background: url('images/spinner-icon-14x14.gif?1410117644') no-repeat center;
@@ -4691,9 +4694,9 @@ pre[class*="brush:"]
 	max-height: var(--code-block-raw-height); /* provided by inline style from JavaScript */
 	--transition-timing-and-effect: 0.2s ease-in-out;
 	--syntaxhighlighter-collapsible-transition: max-height var(--transition-timing-and-effect);
-	transition: 
-		var(--syntaxhighlighter-collapsible-transition), 
-		transform var(--transition-timing-and-effect), 
+	transition:
+		var(--syntaxhighlighter-collapsible-transition),
+		transform var(--transition-timing-and-effect),
 		width var(--transition-timing-and-effect);
 	position: relative;
 	z-index: 1;
@@ -5294,7 +5297,7 @@ ul.features-drawer-list--hidden
 	transform: translateX(
 		calc(
 			var(
-				--offset-to-qa-body-wrapper, 
+				--offset-to-qa-body-wrapper,
 				var(--qa-body-wrapper-margin-inline)
 			) * -1px
 		)


### PR DESCRIPTION
Problem zaobserwowany tutaj: https://forum.pasja-informatyki.pl/576358/nie-dziala-ajax-na-hostingu?show=576365#c576365 po sugestii z [MajkiIT/polish-ads-filter#21376 ](https://github.com/MajkiIT/polish-ads-filter/issues/21376)

Obrazki wstawiane do postów przez CKEditora otrzymują inline atrybuty width i height z wymiarami. Przy uploadzie do nas na serwer CKEditor podstawia je dostosowane do potrzeb widoku na forum. Jednak w przypadku wstawienia obrazku z linka zewnętrznego tak już się nie dzieje, domyślnie podstawiane są oryginalne wymiary obrazu. Do tego Użytkownik może je ręcznie zmienić na dowolne, a więc i bardzo duże. Szerokość pomimo tego dobierana jest na maksymalną możliwą, ale wysokość już nie ma ograniczenia i wtedy wszystko się sypie, bo obraz staje się zupełnie nieczytelny po rozciągnięciu, jak w podlinkowanym przykładzie.

Najprostsza propozycja poprawki to wg mnie wymuszenie automatycznego dostosowania wysokości. Nie możemy ręcznie wymusić też szerokości na 100%, ponieważ edytor daje takie opcje, że ktoś może wstawić mały obraz i obok umieścić tekst, choć nad sensem tego bym raczej dyskutował, ale tak było i jest. Docelowo warto byłoby to pewnie poprawić w samym CKEditorze, aby wstawiał dobry wymiar dla obrazów z linku lub dodać jakiś limit, aby to miało sens już na etapie wpisywania, ale pomimo tego należy zadziałać dla obrazków, które już są dodane w obecnych postach.