### PR TITLE
Przekierowanie pytania na pełny adres - poprawka gdy pusty adres

### DIFF
--- a/forum/qa-include/pages/question.php
+++ b/forum/qa-include/pages/question.php
@@ -83,7 +83,7 @@
 		return include QA_INCLUDE_DIR.'qa-page-not-found.php';
 
 	$validurl = qa_q_request($question['postid'], $question['title']);
-	if (qa_request() !== $validurl) {
+	if (qa_request() !== $validurl && trim($validurl, '/') !== $question['postid']) {
 		$pagestart = qa_get_start();
 		$url = qa_path_html($validurl, !empty($pagestart) ? ['start' => $pagestart] : null, qa_opt('site_url'));
 


### PR DESCRIPTION
Poprawka do #308
Przekierowanie jest ogólnie ok, z tym że w Q2A może dojść do takiej dziwnej sytuacji, gdy tekst w adresie będzie pusty - np. tytuł pytania to "........", a więc do adresu nie trafia nic, bo bierze tylko litery i myślniki. Standardowo takie sytuacje nie występują, ale gdy autor np. próbuje usunąć treść pytania poprzez edycję, to się zdarza. Występuje wtedy problem z pętlą przekierowań i nie można wejść na widok pytania.