### PR TITLE
Poprawka zaznaczania nicku autora, gdy występuje użytkownik niezalogowany

### DIFF
--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -317,7 +317,7 @@ function qa_ajax_error()
                 [].slice.call( document.querySelectorAll( query ) ).forEach( function( replyType ) {
                     var nick = replyType.querySelector( '.nickname' );
 
-                    if ( nick.textContent === authorNick ) {
+                    if ( nick && nick.textContent === authorNick ) {
                         nick.classList.add( 'topic-author' );
                     }
                 } );

--- a/forum/qa-content/qa-page.js
+++ b/forum/qa-content/qa-page.js
@@ -307,6 +307,9 @@ function qa_ajax_error()
     function styleTopicAuthor() {
 
         var author = document.querySelector( '.qa-q-view-who-data .nickname' );
+        if ( !author ) {
+            return;
+        }
         var authorNick = author.textContent;
         author.classList.add( 'topic-author' );
 


### PR DESCRIPTION
Sypało błędem na konsoli w sytuacji, gdy w komentarzach pod pytaniem był autor niezalogowany (#317), podobny problem był też gdy autorem danego pytania był niezalogowany.