### PR TITLE
Update Docker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
         - XDEBUG_IDEKEY=PHPSTORM
         - XDEBUG_AUTOSTART=1
         - XDEBUG_REMOTE_LOG=
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - .:/var/www/html
       - ./docker/apache2:/var/log/apache2

--- a/docker/www/Dockerfile
+++ b/docker/www/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache-stretch
+FROM php:7.3-apache-buster
 
 ARG XDEBUG_REMOTE_ENABLE=1
 ARG XDEBUG_REMOTE_CONNECT_BACK=0


### PR DESCRIPTION
Podbiłem wersję obrazu Dockerowego do nowszego Debiana, gdyż na obecnej wersji obraz nie chciał się już zbudować. Do tego dodałem poprawkę dla linuksowych hostów Dockera, zapewniającą poprawne działanie host.docker.internal (używane np. przy Xdebugu)