### PR TITLE
Optymalizacja widgetu od Advent of Code

### DIFF
--- a/forum/qa-plugin/adventofcode-widget/qa-plugin.php
+++ b/forum/qa-plugin/adventofcode-widget/qa-plugin.php
@@ -19,6 +19,8 @@ if (!defined('QA_VERSION')) {
     exit();
 }
 
+require_once 'src/adventofcode-content.php';
+
 qa_register_plugin_module('widget', 'src/adventofcode-widget.php', 'adventofcode_widget', 'Advent of Code');
 qa_register_plugin_module('page', 'src/adventofcode-page.php', 'adventofcode_page', 'Advent of Code');
 qa_register_plugin_layer('src/adventofcode-layer.php', 'Advent of Code layer');

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-content.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-content.php
@@ -1,0 +1,95 @@
+<?php
+
+class adventofcode_content
+{
+    public function loadFromPage(string $year, string $leaderboard, string $session): array
+    {
+        $response = $this->getResponse($year, $leaderboard, $session);
+        if ($response === null) {
+            return [];
+        }
+
+        return $this->parseResponse($response);
+    }
+
+    public function resultToCsv(array $users): string
+    {
+        $csv = fopen('php://memory', 'r+');
+        foreach ($users as $user) {
+            fputcsv($csv, $user);
+        }
+        rewind($csv);
+
+        return stream_get_contents($csv);
+    }
+
+    public function csvToResult(?string $csv): array
+    {
+        if (empty($csv)) {
+            return [];
+        }
+
+        $users = [];
+        $rows = explode(PHP_EOL, $csv);
+        foreach ($rows as $row) {
+            if (empty($row)) {
+                continue;
+            }
+
+            [$name, $score, $stars] = str_getcsv($row);
+            $users[] = [
+                'name' => $name,
+                'score' => $score,
+                'stars' => $stars,
+            ];
+        }
+
+        return $users;
+    }
+
+    private function getResponse(string $year, string $leaderboard, string $session)
+    {
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_URL, "https://adventofcode.com/{$year}/leaderboard/private/view/{$leaderboard}.json");
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_COOKIE, 'session=' . $session);
+        $aocResponse = curl_exec($curl);
+        $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        curl_close($curl);
+
+        if ($httpCode !== 200) {
+            return null;
+        }
+
+        return $aocResponse;
+    }
+
+    private function parseResponse(string $response): array
+    {
+        $data = json_decode($response, true);
+        if (!$data) {
+            return [];
+        }
+
+        $users = [];
+        foreach ($data['members'] as $member) {
+            $stars = '';
+            $days = $member['completion_day_level'];
+            foreach (range(1, 25) as $day) {
+                $stars .= !empty($days[$day]) ? count($days[$day]) : 0;
+            }
+
+            $users[] = [
+                'name' => $member['name'] ?? ('Anonim '.$member['id']),
+                'score' => $member['local_score'],
+                'stars' => $stars,
+            ];
+        }
+
+        usort($users, function($userA, $userB) {
+            return $userB['score'] <=> $userA['score'];
+        });
+
+        return $users;
+    }
+}

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-content.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-content.php
@@ -80,7 +80,7 @@ class adventofcode_content
             }
 
             $users[] = [
-                'name' => $member['name'] ?? ('Anonim '.$member['id']),
+                'name' => htmlentities($member['name'] ?? ('Anonim '.$member['id'])),
                 'score' => $member['local_score'],
                 'stars' => $stars,
             ];

--- a/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
+++ b/forum/qa-plugin/adventofcode-widget/src/adventofcode-page.php
@@ -2,6 +2,13 @@
 
 class adventofcode_page
 {
+    private $content;
+
+    public function __construct()
+    {
+        $this->content = new adventofcode_content();
+    }
+
     public function match_request($request)
     {
         return $request === 'advent-of-code' && qa_opt('adventofcode_widget_enabled') == 1;
@@ -9,8 +16,7 @@ class adventofcode_page
 
     public function process_request()
     {
-        $users = json_decode(qa_opt('adventofcode_widget_content'), true);
-        $users = $this->fill_missing_days($users);
+        $users = $this->content->csvToResult(qa_opt('adventofcode_widget_content'));
         $year = qa_opt('adventofcode_widget_year');
         $leaderboard = qa_opt('adventofcode_widget_leaderboard_id');
         $code = qa_opt('adventofcode_widget_leaderboard_code');
@@ -53,13 +59,13 @@ class adventofcode_page
 
             // Ranking
             $html .= '<ol class="aoc-page__ranking">';
-            foreach($users as ['name' => $username, 'score' => $score, 'stars' => $stars, 'link' => $userlink]) {
+            foreach ($users as ['name' => $username, 'score' => $score, 'stars' => $stars]) {
                 $html .= '<li>';
                 $html .= '    <span class="aoc-page__score">'.$score.'</span>';
-                foreach($stars as $day => $dayScore) {
-                    $html .= '<span class="aoc-page__star aoc-page__star--'.$dayScore.'" title="'.$username.' - Dzień: '.$day.'">*</span>';
+                foreach (range(1, 25) as $day) {
+                    $html .= '<span class="aoc-page__star aoc-page__star--'.$stars[$day - 1].'" title="'.$username.' - Dzień: '.$day.'">*</span>';
                 }
-                $html .= '    <span class="aoc-page__username">'.$this->wrap_username_in_anchor($username, $userlink).'</span>';
+                $html .= '    <span class="aoc-page__username">'.$username.'</span>';
                 $html .= '</li>';
             }
             $html .= '</ol>';
@@ -74,11 +80,6 @@ class adventofcode_page
         $html .= '<p>Powodzenia!</p>';
 
         return $html;
-    }
-
-    private function wrap_username_in_anchor($username, $userlink)
-    {
-        return isset($userlink) ? '<a href="'.$userlink.'" target="_blank">'.$username.'</a>' : $username;
     }
 
     private function get_css()
@@ -153,20 +154,5 @@ class adventofcode_page
                 }
             }
         ';
-    }
-
-    private function fill_missing_days($users)
-    {
-        foreach($users as &$user) {
-            $stars = &$user['stars'];
-
-            foreach(range(1, 25) as $day) {
-                $stars[$day] = $stars[$day] ?? 0;
-            }
-
-            ksort($stars);
-        }
-
-        return $users;
     }
 }


### PR DESCRIPTION
Zbliża się kolejna edycja Advent of Code, a nasz widget w ostatnim roku zepsuł się ze względu na zbyt dużą ilość danych - fixes #314 

Przygotowałem więc poprawkę, która trochę go usprawnia. Zgodnie z sugestią argeento w issue, wyrzuciłem sporo zbędnych danych, a dodatkowo wszystko trzymane teraz jest jako csv. Finalnie dla zeszłorocznych danych całość zajmuje około 3300 znaków, czyli spadło o ponad połowę. Mam nadzieję, że na kolejne lata będzie to wystarczające. Docelowo jak tam wspomniałem można byłoby to przerobić tak, aby zachowywać wyniki także dla zeszłych lat u nas w bazie i wtedy całkowicie inaczej zapisywać wyniki.