### PR TITLE
Usuwanie komentarzy i pustych tagów HTML z treści posta

### DIFF
--- a/forum/qa-plugin/ckeditor4/CkEditor.php
+++ b/forum/qa-plugin/ckeditor4/CkEditor.php
@@ -378,6 +378,7 @@ class CkEditor
 
     function read_post($fieldname) {
         $html=qa_post_text($fieldname);
+        $html = $this->clearHtmlContent($html);
 
         $htmlformatting=preg_replace('/<\s*\/?\s*(br|p)\s*\/?\s*>/i', '', $html); // remove <p>, <br>, etc... since those are OK in text
 
@@ -395,6 +396,19 @@ class CkEditor
                 'content' => $viewer->get_text($html, 'html', array())
             );
         }
+    }
+
+    private function clearHtmlContent(string $html): string
+    {
+        // remove comments
+        $html = preg_replace('/<!--.*?-->/ms', '', $html);
+
+        // remove empty tags from end
+        do {
+            $html = preg_replace('/<(\w+)(?:\s[^>]*)?>\s*(?:<br\s*\/?>|\s|&nbsp;)*<\/\1>\s*$/i', '', $html, -1, $count);
+        } while ($count > 0);
+
+        return $html;
     }
 
     private function setDefaultToolbar()


### PR DESCRIPTION
Jeden z forumowiczów zgłosił błąd: https://forum.pasja-informatyki.pl/597928/automatyczny-tag-dolacza-sie-do-postow Powoduje on zbędne dodawanie komentarza HTML gdy nastąpiło przeklejenie treści z innego edytora w formacie HTML, np. Notion. Przygotowałem poprawkę, która usuwa komentarze z treści oraz usuwa także puste znaczniki (np. `<p> </p>`, `<p><br></p>` itp.) z końca treści, co przyda się nie tylko po usuwaniu z niej komentarza, ale ogólnie gdy ktoś po prostu zostawi w poście na końcu zbędne puste linie.

Przykładowe wejście przekazywane przez CKEditora:
```html
<p>Przykładowy <strong>długi</strong> tekst</p>
<p>&lt;!-- test komentarza w treści --&gt;</p>
<pre class="brush:plain;">
&lt;p&gt;test&lt;/p&gt;
&lt;!-- test komentarza w kodzie --&gt;</pre>
<p><!-- notionvc: 593a1c17-4a31-2be2-5221-427b5da02363 --></p>
```

Wyjście przed poprawką:
```html
<p>Przykładowy <strong>długi</strong> tekst</p>
<p>&lt;!-- test komentarza w treści --&gt;</p>
<pre class="brush:plain;">
&lt;p&gt;test&lt;/p&gt;
&lt;!-- test komentarza w kodzie --&gt;</pre>
<p>&lt;!-- notionvc: 593a1c17-4a31-2be2-5221-427b5da02363 --&gt;</p>
```

Wyjście po poprawce:
```html
<p>Przykładowy <strong>długi</strong> tekst</p>
<p>&lt;!-- test komentarza w treści --&gt;</p>
<pre class="brush:plain;">
&lt;p&gt;test&lt;/p&gt;
&lt;!-- test komentarza w kodzie --&gt;</pre>
```