### PR TITLE
Poprawka sprawdzania uprawnień przy dołączaniu do Discorda

### DIFF
--- a/forum/qa-plugin/discord-integration/lang/default.php
+++ b/forum/qa-plugin/discord-integration/lang/default.php
@@ -9,8 +9,9 @@ return [
     'success_joined' => 'Successfully connected and joined to server',
     'disconnect_button' => 'Disconnect and remove connection',
     'disconnected_success' => 'Your account has successfully disconnected.',
-    'user_blocked' => 'Your account is blocked - you don\'t join to Discord.',
+    'cannot_join' => 'You cannot join to Discord.',
     'already_connected_account' => 'This Discord account is already connected to other user.',
+    'confirm_email' => 'Please ^5confirm your email address^6 to join.',
 
     'client_id' => 'Discord API client ID',
     'client_secret' => 'Discord API secret key',

--- a/forum/qa-plugin/discord-integration/lang/pl.php
+++ b/forum/qa-plugin/discord-integration/lang/pl.php
@@ -9,8 +9,9 @@ return [
     'success_joined' => 'Gratulacje, dołączyłeś właśnie na serwer! Teraz wystarczy, że włączysz Discorda, wybierzesz nasz serwer i możesz rozmawiać.',
     'disconnect_button' => 'Odłącz powiązanie i opuść serwer',
     'disconnected_success' => 'Twoje konto zostało pomyślnie odłączone.',
-    'user_blocked' => 'Twoje konto jest zablokowane - nie możesz dołączyć do Discorda.',
+    'cannot_join' => 'Nie możesz obecnie dołączyć do Discorda.',
     'already_connected_account' => 'To konto Discord jest już połączone z innym użytkownikiem.',
+    'confirm_email' => '^5Potwierdź swój adres email^6, aby dołączyć.',
 
     'client_id' => 'ID klienta API Discord',
     'client_secret' => 'Sekretny klucz klienta API Discord',


### PR DESCRIPTION
Podczas dołączania do Discorda wcześniej nie sprawdzaliśmy czy użytkownik potwierdził adres email lub czy adres IP nie jest zablokowany. Po poprawce będzie to uwzględniane.